### PR TITLE
Java binding for Houdini's Typed Object Model

### DIFF
--- a/cssom-api/build.gradle
+++ b/cssom-api/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+	id 'web-apis.java-conventions'
+}
+
+description = 'io.sf.carte:cssom-api'
+
+version = '0.1'
+
+publishing.publications.maven(MavenPublication).pom {
+	description = "CSS OM 1.0-pre API Java binding"
+}

--- a/cssom-api/src/main/java/module-info.java
+++ b/cssom-api/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018-2023 World Wide Web Consortium,
+ *
+ * (Massachusetts Institute of Technology, European Research Consortium for
+ * Informatics and Mathematics, Keio University). All Rights Reserved. This
+ * work is distributed under the W3C(r) Software License [1] in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+ * 
+ * Other copyrights:
+ * Copyright (c) 2020-2024, Carlos Amengual
+ */
+
+/**
+ * CSS Typed OM Java binding.
+ */
+module org.w3c.css.om {
+
+	exports org.w3c.api;
+	exports org.w3c.css.om;
+	exports org.w3c.css.om.typed;
+	exports org.w3c.css.om.unit;
+	exports org.w3c.css.om.view;
+
+	requires jdk.xml.dom;
+	requires transitive java.xml;
+
+}

--- a/cssom-api/src/main/java/org/w3c/api/AbstractDOMException.java
+++ b/cssom-api/src/main/java/org/w3c/api/AbstractDOMException.java
@@ -1,0 +1,35 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.api;
+
+import org.w3c.dom.DOMException;
+
+/**
+ * Abstract DOM exception in Web APIs.
+ */
+public class AbstractDOMException extends DOMException {
+
+	private static final long serialVersionUID = 1L;
+
+	protected AbstractDOMException(short code, String message) {
+		super(code, message);
+	}
+
+	protected AbstractDOMException(short code, Throwable cause) {
+		super(code, null);
+		initCause(cause);
+	}
+
+	protected AbstractDOMException(short code, String message, Throwable cause) {
+		super(code, message);
+		initCause(cause);
+	}
+
+}

--- a/cssom-api/src/main/java/org/w3c/api/DOMSyntaxException.java
+++ b/cssom-api/src/main/java/org/w3c/api/DOMSyntaxException.java
@@ -1,0 +1,33 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.api;
+
+import org.w3c.dom.DOMException;
+
+/**
+ * Syntax exception in Web APIs.
+ */
+public class DOMSyntaxException extends AbstractDOMException {
+
+	private static final long serialVersionUID = 1L;
+
+	public DOMSyntaxException(String message) {
+		super(DOMException.SYNTAX_ERR, message);
+	}
+
+	public DOMSyntaxException(Throwable cause) {
+		super(DOMException.SYNTAX_ERR, cause);
+	}
+
+	public DOMSyntaxException(String message, Throwable cause) {
+		super(DOMException.SYNTAX_ERR, message, cause);
+	}
+
+}

--- a/cssom-api/src/main/java/org/w3c/api/DOMTypeException.java
+++ b/cssom-api/src/main/java/org/w3c/api/DOMTypeException.java
@@ -1,0 +1,33 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.api;
+
+import org.w3c.dom.DOMException;
+
+/**
+ * Type exception in Web APIs.
+ */
+public class DOMTypeException extends AbstractDOMException {
+
+	private static final long serialVersionUID = 1L;
+
+	public DOMTypeException(String message) {
+		super(DOMException.TYPE_MISMATCH_ERR, message);
+	}
+
+	public DOMTypeException(Throwable cause) {
+		super(DOMException.TYPE_MISMATCH_ERR, cause);
+	}
+
+	public DOMTypeException(String message, Throwable cause) {
+		super(DOMException.TYPE_MISMATCH_ERR, message);
+	}
+
+}

--- a/cssom-api/src/main/java/org/w3c/api/package-info.java
+++ b/cssom-api/src/main/java/org/w3c/api/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Classes used by all the W3C APIs.
+ */
+package org.w3c.api;

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSConditionRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSConditionRule.java
@@ -1,0 +1,37 @@
+/*
+ * This software extends interfaces defined by CSS Conditional Rules Module Level 3
+ *  (https://www.w3.org/TR/css3-conditional/).
+ * Copyright © 2013 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+import org.w3c.dom.DOMException;
+
+/**
+ * Represents all the "conditional" at-rules, which consist of a condition and a statement
+ * block.
+ */
+public interface CSSConditionRule extends CSSGroupingRule {
+
+	/**
+	 * Gets the serialization of the condition of this rule.
+	 * 
+	 * @return the serialization of the condition of this rule.
+	 */
+	String getConditionText();
+
+	/**
+	 * Sets the condition associated to this rule.
+	 * 
+	 * @param conditionText
+	 *            the condition text.
+	 * @throws DOMException if the condition could not be parsed.
+	 */
+	void setConditionText(String conditionText) throws DOMException;
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSCounterStyleRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSCounterStyleRule.java
@@ -1,0 +1,25 @@
+/*
+ * This software includes interfaces defined by CSS Counter Styles Level 3
+ *  (https://www.w3.org/TR/css-counter-styles-3/).
+ * Copyright © 2017 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * Counter-style rule. @see <a href="https://www.w3.org/TR/css-counter-styles-3/">CSS Counter Styles Level 3</a>.
+ */
+public interface CSSCounterStyleRule extends CSSRule {
+
+	/**
+	 * Gets the counter-style name.
+	 * 
+	 * @return the counter-style name.
+	 */
+	String getName();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSFontFaceRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSFontFaceRule.java
@@ -1,0 +1,26 @@
+/*
+ * This software extends interfaces defined by CSS Object Model draft
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * A CSS font-face rule.
+ *
+ */
+public interface CSSFontFaceRule extends CSSRule {
+
+	/**
+	 * Get the style that is declared by this rule.
+	 *
+	 * @return the style declaration.
+	 */
+	CSSStyleDeclaration getStyle();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSGroupingRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSGroupingRule.java
@@ -1,0 +1,53 @@
+/*
+ * This software extends interfaces defined by CSS Conditional Rules Module Level 3
+ *  (https://www.w3.org/TR/css3-conditional/).
+ * Copyright © 2013 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+import org.w3c.dom.DOMException;
+
+/**
+ * Represents an at-rule that contains other rules nested inside itself.
+ */
+public interface CSSGroupingRule extends CSSRule {
+
+	/**
+	 * Get the list of CSS rules nested inside the grouping rule.
+	 * 
+	 * @return a CSSRuleList object for the list of CSS rules nested inside the grouping rule.
+	 */
+	CSSRuleList getCssRules();
+
+	/**
+	 * Inserts a new rule into this grouping rule collection.
+	 * 
+	 * @param rule
+	 *            The parsable text representing the rule.
+	 * @param index
+	 *            The index within the collection of the rule before which to insert the
+	 *            specified rule. If the specified index is equal to the length of the rule
+	 *            collection, the rule will be added to its end.
+	 * @return the index at which the rule was inserted.
+	 * @throws DOMException
+	 *             if the index is out of bounds or there was a problem parsing the rule.
+	 */
+	int insertRule(String rule, int index) throws DOMException;
+
+	/**
+	 * Removes a CSS rule from the CSS rule list returned by {@link #getCssRules()} at
+	 * <code>index</code>.
+	 * 
+	 * @param index the rule list index at which the rule must be removed.
+	 * @throws DOMException
+	 *             INDEX_SIZE_ERR if <code>index</code> is greater than or equal to
+	 *             {@link #getCssRules()}.getLength().
+	 */
+	void deleteRule(int index) throws DOMException;
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSKeyframeRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSKeyframeRule.java
@@ -1,0 +1,33 @@
+/*
+ * This software extends interfaces defined by CSS Animations Level 1
+ *  (https://drafts.csswg.org/css-animations/).
+ * Copyright © 2018 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * The CSSKeyframeRule interface represents the style rule for a single key.
+ *
+ */
+public interface CSSKeyframeRule extends CSSRule {
+
+	/**
+	 * Gets the keyframe selector as a comma-separated list of percentage values.
+	 * 
+	 * @return the keyframe selector.
+	 */
+	String getKeyText();
+
+	/**
+	 * Get the style that is declared by this rule.
+	 *
+	 * @return the style declaration.
+	 */
+	CSSStyleDeclaration getStyle();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSKeyframesRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSKeyframesRule.java
@@ -1,0 +1,75 @@
+/*
+ * This software extends interfaces defined by CSS Animations Level 1
+ *  (https://drafts.csswg.org/css-animations/).
+ * Copyright © 2018 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * <code>CSSKeyframesRule</code> represents a complete set of keyframes for a single
+ * animation.
+ *
+ */
+public interface CSSKeyframesRule extends CSSRule {
+
+	/**
+	 * Gets the name of the keyframes.
+	 * 
+	 * @return the name of the keyframes.
+	 */
+	String getName();
+
+	/**
+	 * Sets the name of the keyframes.
+	 * 
+	 * @param name the name of the keyframes.
+	 */
+	void setName(String name);
+
+	/**
+	 * Gets the list of keyframe rules.
+	 * 
+	 * @return the list of keyframe rules.
+	 */
+	CSSRuleList getCssRules();
+
+	/**
+	 * Appends a new rule into this keyframes rule collection.
+	 * 
+	 * @param rule
+	 *            The parsable text representing the rule.
+	 */
+	void appendRule(String rule);
+
+	/**
+	 * Deletes the last declared <code>CSSKeyframeRule</code> matching the specified keyframe
+	 * selector from this <code>keyframes</code> rule collection. If no matching rule exists,
+	 * the method does nothing.
+	 * <p>
+	 * The number and order of the values in the specified keyframe selector must match those
+	 * of the targeted keyframe rule(s). The match is not sensitive to white space around the
+	 * values in the list.
+	 * 
+	 * @param select
+	 *            The keyframe selector of the rule to be deleted: a comma-separated list of
+	 *            keywords or percentage values between 0% and 100%.
+	 */
+	void deleteRule(String select);
+
+	/**
+	 * The findRule returns the last declared CSSKeyframeRule matching the specified keyframe
+	 * selector. If no matching rule exists, the method does nothing.
+	 * 
+	 * @param select
+	 *            The keyframe selector of the rule to be deleted: a comma-separated list of
+	 *            keywords or percentage values between 0% and 100%.
+	 * @return the found rule, or null if no rule was found.
+	 */
+	CSSKeyframeRule findRule(String select);
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSMarginRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSMarginRule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright ©2017 World Wide Web Consortium, (Massachusetts Institute of Technology, European
+ * Research Consortium for Informatics and Mathematics, Keio University, Beihang). All Rights
+ * Reserved.
+ *
+ * This work is distributed under the W3C® Software License [1] in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * [1] http://www.w3.org/Consortium/Legal/copyright-software
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * Margin rule.
+ */
+public interface CSSMarginRule extends CSSRule {
+
+	/**
+	 * The name of the margin at-rule.
+	 *
+	 * @return the name of the margin at-rule. The @ character is not included in the name.
+	 */
+	String getName();
+
+	/**
+	 * Get the style that is declared by this rule.
+	 *
+	 * @return the style declaration.
+	 */
+	CSSStyleDeclaration getStyle();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSNamespaceRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSNamespaceRule.java
@@ -1,0 +1,34 @@
+/*
+ * This software extends interfaces defined by CSS Object Model draft
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * Namespace rule. @see
+ * <a href="https://www.w3.org/TR/cssom-1/#the-cssnamespacerule-interface">The
+ * <code>CSSNamespaceRule</code> Interface</a>.
+ */
+public interface CSSNamespaceRule extends CSSRule {
+
+	/**
+	 * Get the namespace URI defined by this rule.
+	 * 
+	 * @return the namespace URI.
+	 */
+	String getNamespaceURI();
+
+	/**
+	 * Get the prefix for the declared namespace.
+	 * 
+	 * @return the namespace prefix.
+	 */
+	String getPrefix();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSPageRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSPageRule.java
@@ -1,0 +1,33 @@
+/*
+ * This software extends interfaces defined by CSS Object Model draft
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * A CSS {@literal @}page rule.
+ *
+ */
+public interface CSSPageRule extends CSSRule {
+
+	/**
+	 * Get a serialization of the associated list of CSS page selectors.
+	 * 
+	 * @return a serialization of the page selectors.
+	 */
+	String getSelectorText();
+
+	/**
+	 * Sets the page selectors associated to this rule.
+	 * 
+	 * @param selectorText a parsable serialization of page selectors.
+	 */
+	void setSelectorText(String selectorText);
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSRule.java
@@ -1,0 +1,125 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om;
+/*
+ * This software extends interfaces defined by CSS Object Model draft
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+/**
+ * A CSS rule.
+ *
+ */
+public interface CSSRule extends org.w3c.dom.css.CSSRule {
+
+	/**
+	 * Rule is a <code>CSSUnknownRule</code>.
+	 */
+	short UNKNOWN_RULE = org.w3c.dom.css.CSSRule.UNKNOWN_RULE;
+
+	/**
+	 * Rule is a {@code CSSStyleRule}.
+	 */
+	short STYLE_RULE = org.w3c.dom.css.CSSRule.STYLE_RULE;
+
+	/**
+	 * Rule is a <code>CSSImportRule</code>.
+	 */
+	short IMPORT_RULE = org.w3c.dom.css.CSSRule.IMPORT_RULE;
+
+	/**
+	 * Rule is a {@code CSSMediaRule}.
+	 */
+	short MEDIA_RULE = org.w3c.dom.css.CSSRule.MEDIA_RULE;
+
+	/**
+	 * Rule is a {@code CSSFontFaceRule}.
+	 */
+	short FONT_FACE_RULE = org.w3c.dom.css.CSSRule.FONT_FACE_RULE;
+
+	/**
+	 * Rule is a {@code CSSPageRule}.
+	 */
+	short PAGE_RULE = org.w3c.dom.css.CSSRule.PAGE_RULE;
+
+	/**
+	 * Rule is a {@code CSSKeyframesRule}.
+	 */
+	short KEYFRAMES_RULE = 7;
+
+	/**
+	 * Rule is a {@code CSSKeyframeRule}.
+	 */
+	short KEYFRAME_RULE = 8;
+
+	/**
+	 * Rule is a {@code CSSMarginRule}.
+	 */
+	short MARGIN_RULE = 9;
+
+	/**
+	 * Rule is a {@code CSSNamespaceRule}.
+	 */
+	short NAMESPACE_RULE = 10;
+
+	/**
+	 * Rule is a {@code CSSCounterStyleRule}.
+	 */
+	short COUNTER_STYLE_RULE = 11;
+
+	/**
+	 * Rule is a {@code CSSSupportsRule}.
+	 */
+	short SUPPORTS_RULE = 12;
+
+	short DOCUMENT_RULE = 13;
+
+	/**
+	 * Rule is a {@code CSSFontFeatureValuesRule}.
+	 */
+	short FONT_FEATURE_VALUES_RULE = 14;
+
+	/**
+	 * Rule is a {@code @viewport} rule.
+	 * <p>
+	 * Note: {@code @viewport} rules were
+	 * <a href="https://github.com/w3c/csswg-drafts/issues/4766">removed by W3C in
+	 * February 2020</a>.
+	 * </p>
+	 */
+	short VIEWPORT_RULE = 15;
+
+	short REGION_STYLE_RULE = 16;
+	short CUSTOM_MEDIA_RULE = 17;
+	short PROPERTY_RULE = 18;
+
+	/**
+	 * If this rule is contained inside another rule, return that rule. If it is not nested
+	 * inside any other rules, return <code>null</code>.
+	 *
+	 * @return the containing rule, if any, otherwise <code>null</code>.
+	 */
+	@Override
+	CSSRule getParentRule();
+
+	/**
+	 * Get the style sheet that contains this rule.
+	 *
+	 * @return the style sheet, or null if no sheet contains this rule.
+	 */
+	@Override
+	CSSStyleSheet getParentStyleSheet();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSRuleList.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSRuleList.java
@@ -1,0 +1,37 @@
+/*
+ * This software extends interfaces defined by CSS Object Model
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+import java.util.Iterator;
+
+/**
+ * A rule list with additional utility methods.
+ */
+public interface CSSRuleList extends org.w3c.dom.css.CSSRuleList, Iterable<CSSRule> {
+
+	/**
+	 * Retrieve a CSS rule by ordinal index. The order in this collection represents
+	 * the order of the rules in the CSS style sheet.
+	 * 
+	 * @param index the index in the collection.
+	 * @return the rule at the <code>index</code> position, or <code>null</code> if
+	 *         the index is less than zero or equal or greater to the list length.
+	 */
+	@Override
+	CSSRule item(int index);
+
+	/**
+	 * Returns an iterator over the rules.
+	 */
+	@Override
+	Iterator<CSSRule> iterator();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSStyleDeclaration.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSStyleDeclaration.java
@@ -1,0 +1,122 @@
+/*
+ * This software extends interfaces defined by CSS Object Model draft
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+import org.w3c.css.om.typed.CSSStyleValue;
+import org.w3c.dom.DOMException;
+
+/**
+ * CSS style declaration.
+ */
+public interface CSSStyleDeclaration {
+
+	/**
+	 * A parsable serialization of the declaration.
+	 *
+	 * @return the textual representation of the declaration.
+	 */
+	String getCssText();
+
+	/**
+	 * Parse the given text, and set the contents of this declaration according to
+	 * it.
+	 * 
+	 * @param cssText the serialized style declaration.
+	 */
+	void setCssText(String cssText) throws DOMException;
+
+	/**
+	 * Remove the given property from this declaration.
+	 * 
+	 * @param propertyName the name of the property to remove.
+	 * @return the value of the removed property, or the empty string if that
+	 *         property was not explicitly set in this declaration.
+	 */
+	String removeProperty(String propertyName) throws DOMException;
+
+	/**
+	 * Get the priority that was set to the given property in this declaration.
+	 * 
+	 * @param propertyName the name of the property.
+	 * @return the priority string, or the empty string if no priority was set.
+	 */
+	String getPropertyPriority(String propertyName);
+
+	/**
+	 * Set the value of a property in this declaration, with the given priority.
+	 * 
+	 * @param propertyName the name of the property.
+	 * @param value the property value.
+	 * @param priority the priority.
+	 */
+	void setProperty(String propertyName, String value, String priority) throws DOMException;
+
+	/**
+	 * The number of properties in this declaration.
+	 * 
+	 * @return the number of properties in this declaration.
+	 */
+	int getLength();
+
+	/**
+	 * The name of the property at index {@code index} in this declaration.
+	 * 
+	 * @param index the index.
+	 * @return the name of the property at the given index, or null if the index is
+	 *         less than zero, or greater or equal to the length of this
+	 *         declaration.
+	 */
+	String item(int index);
+
+	/**
+	 * Gets the object representation of the value of a CSS property if it has been
+	 * explicitly set for this declaration block.
+	 * <p>
+	 * If the declaration was created by a factory with the <code>IEVALUES</code>
+	 * flag enabled, the compatibility values shall appear in the cssText
+	 * serializations, but its value won't be returned by this method unless no
+	 * other valid value was previously specified for the property.
+	 *
+	 * @param propertyName The name of the CSS property.
+	 * @return the value of the property if it has been explicitly set for this
+	 *         declaration block. Returns <code>null</code> if the property has not
+	 *         been set, is a shorthand or this implementation does not support it.
+	 */
+	default CSSStyleValue getCSSStyleValue(String propertyName) {
+		return null;
+	}
+
+	/**
+	 * Gets the text value of a CSS property if it has been explicitly set within this
+	 * declaration block.
+	 * <p>
+	 * If the declaration was created by a factory with the <code>IEVALUES</code> flag
+	 * enabled, the compatibility values shall appear in the cssText serializations, but its
+	 * value won't be returned by this method unless no other valid value was previously
+	 * specified for the property.
+	 *
+	 * @param propertyName
+	 *            The name of the CSS property.
+	 * @return the value of the property if it has been explicitly set for this declaration
+	 *         block, or the empty string if the property has not been set or is a shorthand
+	 *         that could not be serialized.
+	 */
+	String getPropertyValue(String propertyName);
+
+	/**
+	 * Retrieves the CSS rule that contains this declaration block.
+	 *
+	 * @return the CSS rule that contains this declaration block or <code>null</code> if this
+	 *         <code>CSSStyleDeclaration</code> is not attached to a <code>CSSRule</code>.
+	 */
+	CSSRule getParentRule();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSStyleException.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSStyleException.java
@@ -1,0 +1,39 @@
+/*
+
+ Copyright (c) 2005-2024, Carlos Amengual.
+
+ Licensed under a BSD-style License. You can find the license here:
+ https://css4j.github.io/LICENSE.txt
+
+ */
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.w3c.css.om;
+
+/**
+ * CSS topmost generic Exception.
+ * 
+ */
+public class CSSStyleException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public CSSStyleException() {
+		super();
+	}
+
+	public CSSStyleException(String message) {
+		super(message);
+	}
+
+	public CSSStyleException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public CSSStyleException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSStyleRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSStyleRule.java
@@ -1,0 +1,44 @@
+/*
+ * This software extends interfaces defined by CSS Object Model
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/* 
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+import org.w3c.dom.DOMException;
+
+/**
+ * A CSS style rule.
+ * 
+ */
+public interface CSSStyleRule extends CSSRule {
+
+	/**
+	 * Get a parsable serialization of the selector(s).
+	 * 
+	 * @return a parsable serialization of the selector list.
+	 */
+	String getSelectorText();
+
+	/**
+	 * Parse the given string and set the selector list according to it.
+	 * 
+	 * @param selectorText a text representation of a selector list, according to
+	 *                     CSS syntax.
+	 * @throws DOMException
+	 */
+	void setSelectorText(String selectorText) throws DOMException;
+
+	/**
+	 * Get the style that is declared by this rule.
+	 *
+	 * @return the style declaration.
+	 */
+	CSSStyleDeclaration getStyle();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSStyleSheet.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSStyleSheet.java
@@ -1,0 +1,43 @@
+/*
+ * This software extends interfaces defined by CSS Object Model draft
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+import org.w3c.css.om.view.MediaQueryList;
+
+/**
+ * A style sheet.
+ */
+public interface CSSStyleSheet extends org.w3c.dom.css.CSSStyleSheet {
+
+	/**
+	 * Gets the collection of all CSS rules contained within the style sheet.
+	 *
+	 * @return the list of all CSS rules contained within the style sheet.
+	 */
+	@Override
+	CSSRuleList getCssRules();
+
+	/**
+	 * Get the destination media for this sheet.
+	 *
+	 * @return the media query list.
+	 */
+	@Override
+	MediaQueryList getMedia();
+
+	/**
+	 * Create a CSS style declaration compatible with this implementation.
+	 *
+	 * @return a CSS style declaration.
+	 */
+	CSSStyleDeclaration createStyleDeclaration();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSStyleSheetList.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSStyleSheetList.java
@@ -1,0 +1,32 @@
+/*
+ * This software implements or extends interfaces defined by CSS Object Model
+ *  (https://www.w3.org/TR/cssom-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * List of extended style sheets.
+ * 
+ * See <a href="https://www.w3.org/TR/cssom-1/#the-stylesheetlist-interface">The
+ *      <code>StyleSheetList</code> Interface</a>.
+ */
+public interface CSSStyleSheetList extends org.w3c.dom.stylesheets.StyleSheetList {
+
+	/**
+	 * retrieve a <code>CSSStyleSheet</code> by ordinal index.
+	 * 
+	 * @param index the index in this list.
+	 * @return the sheet at <code>index</code>, or <code>null</code> if
+	 *         <code>index</code> is less than zero, or greater or equal to the list
+	 *         length.
+	 */
+	@Override
+	CSSStyleSheet item(int index);
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSSupportsRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSSupportsRule.java
@@ -1,0 +1,18 @@
+/*
+ * This software extends interfaces defined by CSS Conditional Rules Module Level 3
+ *  (https://www.w3.org/TR/css3-conditional/).
+ * Copyright © 2013 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/* 
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om;
+
+/**
+ * Represents a ‘{@literal @}supports’ rule.
+ */
+public interface CSSSupportsRule extends CSSConditionRule {
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/package-info.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * CSS Object Model.
+ */
+package org.w3c.css.om;

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSColor.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSColor.java
@@ -1,0 +1,62 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+import org.w3c.api.DOMSyntaxException;
+
+/**
+ * Represents the CSS color() function.
+ */
+public interface CSSColor extends CSSColorValue {
+
+	/**
+	 * Gets the name of the color space.
+	 * 
+	 * @return the color space.
+	 */
+	CSSKeywordValue getColorSpace();
+
+	/**
+	 * Sets the color space.
+	 * 
+	 * @param cs the color space.
+	 */
+	void setColorSpace(String cs);
+
+	/**
+	 * Gets the channels (except alpha).
+	 * 
+	 * @return the channels.
+	 */
+	CSSStyleValueList<? extends CSSNumericValue> getChannels();
+
+	/**
+	 * Gets the value of the {@code alpha} component.
+	 * 
+	 * @return the {@code alpha} component.
+	 */
+	CSSNumericValue getAlpha();
+
+	/**
+	 * Sets the alpha channel as a percentage.
+	 * 
+	 * @param alpha the alpha channel as a percentage.
+	 */
+	void setAlpha(double alpha);
+
+	/**
+	 * Sets the alpha channel.
+	 * 
+	 * @param alpha the alpha channel.
+	 * @throws DOMSyntaxException if alpha is not a percentage.
+	 */
+	void setAlpha(CSSNumericValue alpha) throws DOMSyntaxException;
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSColorValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSColorValue.java
@@ -1,0 +1,17 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+/**
+ * The base interface of all CSS color values.
+ */
+public interface CSSColorValue extends CSSStyleValue {
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSCounterValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSCounterValue.java
@@ -1,0 +1,46 @@
+/*
+
+ Copyright (c) 2005-2023, Carlos Amengual.
+
+ Licensed under a BSD-style License. You can find the license here:
+ https://css4j.github.io/LICENSE.txt
+
+ */
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.w3c.css.om.typed;
+
+/**
+ * A CSS <code>counter()</code> function.
+ */
+public interface CSSCounterValue extends CSSStyleValue {
+
+	/**
+	 * Get the name of this counter.
+	 * 
+	 * @return the name of this counter.
+	 */
+	String getName();
+
+	/**
+	 * Get the counter style.
+	 * 
+	 * @return the counter style, or <code>null</code> if style is the default.
+	 */
+	CSSStyleValue getCounterStyle();
+
+	/**
+	 * Get the separator.
+	 * <p>
+	 * If no separator was set, returns the empty string.
+	 * </p>
+	 * 
+	 * @return the separator.
+	 */
+	default String getSeparator() {
+		return "";
+	}
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSImageValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSImageValue.java
@@ -1,0 +1,17 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+/**
+ * Represents CSS images.
+ */
+public interface CSSImageValue extends CSSStyleValue {
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSKeywordValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSKeywordValue.java
@@ -1,0 +1,34 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+import org.w3c.api.DOMTypeException;
+
+/**
+ * Represents CSS keywords and other identifiers.
+ */
+public interface CSSKeywordValue extends CSSStyleValue {
+
+	/**
+	 * Gets the value.
+	 * 
+	 * @return the value.
+	 */
+	String getValue();
+
+	/**
+	 * Sets the value.
+	 * 
+	 * @param value the value.
+	 * @throws DOMTypeException if the value is empty or {@code null}.
+	 */
+	void setValue(String value) throws DOMTypeException;
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSLCH.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSLCH.java
@@ -1,0 +1,107 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+import org.w3c.api.DOMSyntaxException;
+
+/**
+ * Represents the CSS lch() function.
+ */
+public interface CSSLCH extends CSSColorValue {
+
+	/**
+	 * Gets the value of the {@code l} component.
+	 * 
+	 * @return the {@code l} component.
+	 */
+	CSSNumericValue getL();
+
+	/**
+	 * Sets the {@code l} component as a percentage.
+	 * 
+	 * @param l the {@code l} component as a percentage.
+	 */
+	void setL(double l);
+
+	/**
+	 * Sets the {@code l} component.
+	 * 
+	 * @param l the {@code l} component.
+	 * @throws DOMSyntaxException if the component is not a &lt;percentage&gt;
+	 */
+	void setL(CSSNumericValue l) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code c} component.
+	 * 
+	 * @return the {@code c} component.
+	 */
+	CSSNumericValue getC();
+
+	/**
+	 * Sets the {@code c} component as a percentage.
+	 * 
+	 * @param c the {@code c} component as a percentage.
+	 */
+	void setC(double c);
+
+	/**
+	 * Sets the {@code c} component.
+	 * 
+	 * @param c the {@code c} component.
+	 * @throws DOMSyntaxException if the component is not a &lt;percentage&gt;
+	 */
+	void setC(CSSNumericValue c) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code h} component.
+	 * 
+	 * @return the {@code h} component.
+	 */
+	CSSNumericValue getH();
+
+	/**
+	 * Sets the {@code h} component as an angle in degrees.
+	 * 
+	 * @param h the {@code h} component in degrees.
+	 */
+	void setH(double h);
+
+	/**
+	 * Sets the {@code h} component.
+	 * 
+	 * @param h the {@code h} component.
+	 * @throws DOMSyntaxException if the component is not an &lt;angle&gt;
+	 */
+	void setH(CSSNumericValue h) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code alpha} component.
+	 * 
+	 * @return the {@code alpha} component.
+	 */
+	CSSNumericValue getAlpha();
+
+	/**
+	 * Sets the alpha channel as a percentage.
+	 * 
+	 * @param alpha the alpha channel as a percentage.
+	 */
+	void setAlpha(double alpha);
+
+	/**
+	 * Sets the alpha channel.
+	 * 
+	 * @param alpha the alpha channel.
+	 * @throws DOMSyntaxException if alpha is not a percentage.
+	 */
+	void setAlpha(CSSNumericValue alpha) throws DOMSyntaxException;
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSLab.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSLab.java
@@ -1,0 +1,107 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+import org.w3c.api.DOMSyntaxException;
+
+/**
+ * Represents the CSS lab() function.
+ */
+public interface CSSLab extends CSSColorValue {
+
+	/**
+	 * Gets the value of the {@code l} component.
+	 * 
+	 * @return the {@code l} component.
+	 */
+	CSSNumericValue getL();
+
+	/**
+	 * Sets the {@code l} component as a percentage.
+	 * 
+	 * @param l the {@code l} component as a percentage.
+	 */
+	void setL(double l);
+
+	/**
+	 * Sets the {@code l} component.
+	 * 
+	 * @param l the {@code l} component.
+	 * @throws DOMSyntaxException if the component is not a &lt;percentage&gt;
+	 */
+	void setL(CSSNumericValue l) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code a} component.
+	 * 
+	 * @return the {@code a} component.
+	 */
+	CSSNumericValue getA();
+
+	/**
+	 * Sets the {@code a} component.
+	 * 
+	 * @param a the {@code a} component.
+	 */
+	void setA(double a);
+
+	/**
+	 * Sets the {@code a} component.
+	 * 
+	 * @param a the {@code a} component.
+	 * @throws DOMSyntaxException if the component is not a &lt;number&gt;
+	 */
+	void setA(CSSNumericValue a) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code b} component.
+	 * 
+	 * @return the {@code b} component.
+	 */
+	CSSNumericValue getB();
+
+	/**
+	 * Sets the {@code b} component.
+	 * 
+	 * @param b the {@code b} component.
+	 */
+	void setB(double b);
+
+	/**
+	 * Sets the {@code b} component.
+	 * 
+	 * @param b the {@code b} component.
+	 * @throws DOMSyntaxException if the component is not a &lt;number&gt;
+	 */
+	void setB(CSSNumericValue b) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code alpha} component.
+	 * 
+	 * @return the {@code alpha} component.
+	 */
+	CSSNumericValue getAlpha();
+
+	/**
+	 * Sets the alpha channel as a percentage.
+	 * 
+	 * @param alpha the alpha channel as a percentage.
+	 */
+	void setAlpha(double alpha);
+
+	/**
+	 * Sets the alpha channel.
+	 * 
+	 * @param alpha the alpha channel.
+	 * @throws DOMSyntaxException if alpha is not a percentage.
+	 */
+	void setAlpha(CSSNumericValue alpha) throws DOMSyntaxException;
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSNumericValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSNumericValue.java
@@ -1,0 +1,111 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+/**
+ * Implemented by all the numeric CSS values.
+ */
+public interface CSSNumericValue extends CSSStyleValue {
+
+	enum CSSNumericBaseType {
+		/** &lt;length&gt; */
+		length,
+		/** &lt;angle&gt; */
+		angle,
+		/** &lt;time&gt; */
+		time,
+		/** &lt;frequency&gt; */
+		frequency,
+		/** &lt;resolution&gt; */
+		resolution,
+		/** &lt;flex&gt; */
+		flex,
+		/** &lt;percentage&gt; */
+		percent
+	};
+
+	/**
+	 * A "map" from types to powers.
+	 */
+	interface CSSNumericType {
+
+		/**
+		 * Get the powers of length in the value.
+		 * 
+		 * @return the powers of length.
+		 */
+		int getLength();
+
+		/**
+		 * Get the powers of angle in the value.
+		 * 
+		 * @return the powers of angle.
+		 */
+		int getAngle();
+
+		/**
+		 * Get the powers of time in the value.
+		 * 
+		 * @return the powers of time.
+		 */
+		int getTime();
+
+		/**
+		 * Get the powers of frequency in the value.
+		 * 
+		 * @return the powers of frequency.
+		 */
+		int getFrequency();
+
+		/**
+		 * Get the powers of resolution in the value.
+		 * 
+		 * @return the powers of resolution.
+		 */
+		int getResolution();
+
+		/**
+		 * Get the powers of flex in the value.
+		 * 
+		 * @return the powers of flex.
+		 */
+		int getFlex();
+
+		/**
+		 * Get the powers of percent in the value.
+		 * 
+		 * @return the powers of percent.
+		 */
+		int getPercent();
+
+		/**
+		 * Get the percent-hint.
+		 * 
+		 * @return the percent-hint.
+		 */
+		CSSNumericValue.CSSNumericBaseType getPercentHint();
+	}
+
+	/**
+	 * Converts this value into one in the given unit.
+	 * 
+	 * @param unit the unit.
+	 * @return the new converted value,
+	 */
+	CSSUnitValue to(String unit);
+
+	/**
+	 * A representation of the type of this value.
+	 * 
+	 * @return a representation of the type of this value.
+	 */
+	CSSNumericType type();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSRGB.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSRGB.java
@@ -1,0 +1,110 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+import org.w3c.api.DOMSyntaxException;
+
+/**
+ * Represents the CSS rgb()/rgba() functions.
+ */
+public interface CSSRGB extends CSSColorValue {
+
+	/**
+	 * Gets the value of the {@code r} component.
+	 * 
+	 * @return the {@code r} component.
+	 */
+	CSSNumericValue getR();
+
+	/**
+	 * Sets the {@code r} component as a percentage.
+	 * 
+	 * @param r the {@code r} component as a percentage.
+	 */
+	void setR(double r);
+
+	/**
+	 * Sets the {@code r} component.
+	 * 
+	 * @param r the {@code r} component.
+	 * @throws DOMSyntaxException if the component is not a &lt;number&gt; or
+	 *                         &lt;percentage&gt;
+	 */
+	void setR(CSSNumericValue r) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code g} component.
+	 * 
+	 * @return the {@code g} component.
+	 */
+	CSSNumericValue getG();
+
+	/**
+	 * Sets the {@code g} component as a percentage.
+	 * 
+	 * @param g the {@code g} component as a percentage.
+	 */
+	void setG(double g);
+
+	/**
+	 * Sets the {@code g} component.
+	 * 
+	 * @param g the {@code g} component.
+	 * @throws DOMSyntaxException if the component is not a &lt;number&gt; or
+	 *                         &lt;percentage&gt;
+	 */
+	void setG(CSSNumericValue g) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code b} component.
+	 * 
+	 * @return the {@code b} component.
+	 */
+	CSSNumericValue getB();
+
+	/**
+	 * Sets the {@code b} component as a percentage.
+	 * 
+	 * @param b the {@code b} component as a percentage.
+	 */
+	void setB(double b);
+
+	/**
+	 * Sets the {@code b} component.
+	 * 
+	 * @param b the {@code b} component.
+	 * @throws DOMSyntaxException if the component is not a &lt;number&gt; or
+	 *                         &lt;percentage&gt;
+	 */
+	void setB(CSSNumericValue b) throws DOMSyntaxException;
+
+	/**
+	 * Gets the value of the {@code alpha} component.
+	 * 
+	 * @return the {@code alpha} component.
+	 */
+	CSSNumericValue getAlpha();
+
+	/**
+	 * Sets the alpha channel as a percentage.
+	 * 
+	 * @param alpha the alpha channel as a percentage.
+	 */
+	void setAlpha(double alpha);
+
+	/**
+	 * Sets the alpha channel.
+	 * 
+	 * @param alpha the alpha channel.
+	 * @throws DOMSyntaxException if alpha is not a percentage.
+	 */
+	void setAlpha(CSSNumericValue alpha) throws DOMSyntaxException;
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSRectValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSRectValue.java
@@ -1,0 +1,49 @@
+/*
+ * This software includes material derived from Document Object Model (DOM)
+ * Level 2 Style Specification (https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/).
+ * Copyright © 1999,2000 W3C® (MIT, INRIA, Keio). All Rights Reserved.
+ * https://www.w3.org/Consortium/Legal/copyright-software-19980720
+ *
+ * Copyright © 2017 Carlos Amengual.
+ */
+/*
+ * SPDX-License-Identifier: W3C-19980720
+ * 
+ */
+
+package org.w3c.css.om.typed;
+
+/**
+ * Interface representing a {@code rect()} function.
+ */
+public interface CSSRectValue {
+
+	/**
+	 * The top of the rectangle.
+	 * 
+	 * @return the top of the rectangle.
+	 */
+	CSSStyleValue getTop();
+
+	/**
+	 * The right of the rectangle.
+	 * 
+	 * @return the right of the rectangle.
+	 */
+	CSSStyleValue getRight();
+
+	/**
+	 * The bottom of the rectangle.
+	 * 
+	 * @return the bottom of the rectangle.
+	 */
+	CSSStyleValue getBottom();
+
+	/**
+	 * The left of the rectangle.
+	 * 
+	 * @return the left of the rectangle.
+	 */
+	CSSStyleValue getLeft();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSStringValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSStringValue.java
@@ -1,0 +1,34 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+import org.w3c.api.DOMTypeException;
+
+/**
+ * Represents CSS strings.
+ */
+public interface CSSStringValue extends CSSStyleValue {
+
+	/**
+	 * Gets the value.
+	 * 
+	 * @return the value.
+	 */
+	String getValue();
+
+	/**
+	 * Sets the value.
+	 * 
+	 * @param value the value.
+	 * @throws DOMTypeException if the value is empty or {@code null}.
+	 */
+	void setValue(String value) throws DOMTypeException;
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSStyleValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSStyleValue.java
@@ -1,0 +1,24 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+/**
+ * The base interface of all CSS values accessible via the Typed OM API.
+ */
+public interface CSSStyleValue {
+
+	/**
+	 * Serializes this value.
+	 * 
+	 * @return a parsable representation of this value.
+	 */
+	String toString();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSStyleValueList.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSStyleValueList.java
@@ -1,0 +1,32 @@
+/*
+ * Based on css4j's CSSValueList interface.
+ */
+/*
+ * SPDX-License-Identifier: W3C-19980720
+ */
+package org.w3c.css.om.typed;
+
+/**
+ * Typed OM has no list interface, so let's invent one.
+ *
+ */
+public interface CSSStyleValueList<E extends CSSStyleValue> extends CSSStyleValue, Iterable<E> {
+
+	/**
+	 * The number of values in this list.
+	 * 
+	 * @return the number of items in this list.
+	 */
+	int getLength();
+
+	/**
+	 * Retrieve a <code>CSSValue</code> by ordinal index.
+	 * 
+	 * @param index the index in this list.
+	 * @return the value at <code>index</code>, or <code>null</code> if
+	 *         <code>index</code> is less than zero, or greater or equal to the list
+	 *         length.
+	 */
+	E item(int index);
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSUnitValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSUnitValue.java
@@ -1,0 +1,39 @@
+/*
+ * Interfaces defined by CSS Typed Object Model draft
+ *  (https://www.w3.org/TR/css-typed-om-1/).
+ * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+package org.w3c.css.om.typed;
+
+/**
+ * Numeric values that can be expressed as a single unit (or a naked number or
+ * percentage).
+ */
+public interface CSSUnitValue extends CSSNumericValue {
+
+	/**
+	 * Gets the numeric value in the units represented by this object.
+	 * 
+	 * @return the numeric value.
+	 */
+	double getValue();
+
+	/**
+	 * Set the numeric value in the units represented by this object.
+	 * 
+	 * @param value the numeric value.
+	 */
+	void setValue(double value);
+
+	/**
+	 * Gets the unit string.
+	 * 
+	 * @return the unit string.
+	 */
+	String getUnit();
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/package-info.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * CSS Typed OM.
+ * <p>
+ * This Java binding is experimental and subject to change. Use it at your own
+ * risk.
+ * </p>
+ * 
+ * <p>
+ * See <a href="https://www.w3.org/TR/css-typed-om-1/">CSS Typed OM Level 1</a>.
+ * </p>
+ */
+package org.w3c.css.om.typed;

--- a/cssom-api/src/main/java/org/w3c/css/om/unit/CSSUnit.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/unit/CSSUnit.java
@@ -1,0 +1,366 @@
+/*
+
+ Copyright (c) 2017-2024, Carlos Amengual.
+
+ Licensed under a BSD-style License. You can find the license here:
+ https://css4j.github.io/LICENSE.txt
+
+ */
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.w3c.css.om.unit;
+
+import org.w3c.dom.DOMException;
+
+/**
+ * CSS numeric units.
+ */
+public interface CSSUnit {
+
+	/**
+	 * Dimensionless number.
+	 */
+	short CSS_NUMBER = 0;
+
+	/**
+	 * Number with an unknown dimension.
+	 */
+	short CSS_OTHER = 1;
+
+	/**
+	 * Percentage.
+	 */
+	short CSS_PERCENTAGE = 2;
+
+	/**
+	 * Length ({@code px}).
+	 */
+	short CSS_PX = 3;
+
+	/**
+	 * Length ({@code in}).
+	 */
+	short CSS_IN = 4;
+
+	/**
+	 * Length ({@code pc}).
+	 */
+	short CSS_PC = 5;
+
+	/**
+	 * Length ({@code pt}).
+	 */
+	short CSS_PT = 6;
+
+	/**
+	 * Length ({@code cm}).
+	 */
+	short CSS_CM = 7;
+
+	/**
+	 * Length ({@code mm}).
+	 */
+	short CSS_MM = 8;
+
+	/**
+     * Length ({@code Q}).
+     */
+	short CSS_QUARTER_MM = 9;
+
+	/**
+	 * Font-relative length ({@code em}).
+	 */
+	short CSS_EM = 20;
+
+	/**
+	 * Font-relative length ({@code ex}).
+	 */
+	short CSS_EX = 21;
+
+	/**
+	 * Font-relative length ({@code cap}).
+	 */
+	short CSS_CAP = 22;
+
+	/**
+	 * Font-relative length ({@code ch}).
+	 */
+	short CSS_CH = 23;
+
+	/**
+	 * Font-relative length ({@code ic}).
+	 */
+	short CSS_IC = 24;
+
+	/**
+	 * Font-relative length ({@code lh}).
+	 */
+	short CSS_LH = 25;
+
+	/**
+	 * Font-relative length ({@code rem}).
+	 */
+	short CSS_REM = 26;
+
+	/**
+	 * Font-relative length ({@code rlh}).
+	 */
+	short CSS_RLH = 27;
+
+	/**
+	 * Font-relative length ({@code rex}).
+	 */
+	short CSS_REX = 28;
+
+	/**
+	 * Font-relative length ({@code rch}).
+	 */
+	short CSS_RCH = 29;
+
+	/**
+	 * Font-relative length ({@code ric}).
+	 */
+	short CSS_RIC = 30;
+
+	/**
+	 * Viewport-percentage length ({@code vb}).
+	 */
+	short CSS_VB = 40;
+
+	/**
+	 * Viewport-percentage length ({@code vh}).
+	 */
+	short CSS_VH = 41;
+
+	/**
+	 * Viewport-percentage length ({@code vi}).
+	 */
+	short CSS_VI = 42;
+
+	/**
+	 * Viewport-percentage length ({@code vmax}).
+	 */
+	short CSS_VMAX = 43;
+
+	/**
+	 * Viewport-percentage length ({@code vmin}).
+	 */
+	short CSS_VMIN = 44;
+
+	/**
+	 * Viewport-percentage length ({@code vw}).
+	 */
+	short CSS_VW = 45;
+
+	/**
+     * Resolution ({@code dpi}).
+     */
+	short CSS_DPI = 60;
+
+	/**
+     * Resolution ({@code dpcm}).
+     */
+	short CSS_DPCM = 61;
+
+	/**
+     * Resolution ({@code dppx}).
+     */
+	short CSS_DPPX = 62;
+
+	/**
+	 * Flexible length ({@code fr}). Note that it is <b>not</b> a length.
+	 */
+	short CSS_FR = 70;
+
+	/**
+	 * Angle ({@code deg}).
+	 */
+	short CSS_DEG = 80;
+
+	/**
+	 * Angle ({@code rad}).
+	 */
+	short CSS_RAD = 81;
+
+	/**
+	 * Angle ({@code grad}).
+	 */
+	short CSS_GRAD = 82;
+
+	/**
+     * Angle ({@code turn}).
+     */
+	short CSS_TURN = 83;
+
+	/**
+	 * Time ({@code s}).
+	 */
+	short CSS_S = 90;
+
+	/**
+	 * Time ({@code ms}).
+	 */
+	short CSS_MS = 91;
+
+	/**
+	 * Frequency ({@code Hz}).
+	 */
+	short CSS_HZ = 100;
+
+	/**
+	 * Frequency ({@code kHz}).
+	 */
+	short CSS_KHZ = 101;
+
+	/**
+	 * Invalid CSS unit.
+	 */
+	short CSS_INVALID = 255;
+
+	/**
+	 * Check whether the given unit is a length.
+	 * <p>
+	 * Percentage is not considered an explicit length.
+	 * </p>
+	 * 
+	 * @param unitType the unit type.
+	 * @return true if the unit is a length.
+	 */
+	static boolean isLengthUnitType(short unitType) {
+		return unitType > 2 && unitType < 60;
+	}
+
+	/**
+	 * Check whether the given unit is a relative length.
+	 * 
+	 * @param unitType the unit type.
+	 * @return true if the unit is a relative length.
+	 */
+	static boolean isRelativeLengthUnitType(short unitType) {
+		return unitType >= 20 && unitType < 60;
+	}
+
+	/**
+	 * Check whether the given unit is an angle.
+	 * 
+	 * @param unitType the unit type.
+	 * @return true if the unit is an angle.
+	 */
+	static boolean isAngleUnitType(short unitType) {
+		return unitType > 79 && unitType < 90;
+	}
+
+	/**
+	 * Check whether the given unit is a time.
+	 * 
+	 * @param unitType the unit type.
+	 * @return true if the unit is a time.
+	 */
+	static boolean isTimeUnitType(short unitType) {
+		return unitType == CSS_S || unitType == CSS_MS;
+	}
+
+	/**
+	 * Check whether the given unit is a resolution unit.
+	 * 
+	 * @param unitType the unit type.
+	 * @return true if the unit is a resolution unit.
+	 */
+	static boolean isResolutionUnitType(short unitType) {
+		return unitType >= CSS_DPI && unitType <= CSS_DPPX;
+	}
+
+	/**
+	 * Gives the dimension unit string associated to the given CSS unit type.
+	 * 
+	 * @param unitType the CSS primitive unit type.
+	 * @return the unit string.
+	 * @throws DOMException INVALID_ACCESS_ERR if the unit is not a {@link CSSUnit}
+	 *                      one.
+	 */
+	static String dimensionUnitString(short unitType) throws DOMException {
+		switch (unitType) {
+		case CSS_EM:
+			return "em";
+		case CSS_EX:
+			return "ex";
+		case CSS_PX:
+			return "px";
+		case CSS_IN:
+			return "in";
+		case CSS_CM:
+			return "cm";
+		case CSS_MM:
+			return "mm";
+		case CSS_PT:
+			return "pt";
+		case CSS_PC:
+			return "pc";
+		case CSS_PERCENTAGE:
+			return "%";
+		case CSS_DEG:
+			return "deg";
+		case CSS_GRAD:
+			return "grad";
+		case CSS_RAD:
+			return "rad";
+		case CSS_MS:
+			return "ms";
+		case CSS_S:
+			return "s";
+		case CSS_HZ:
+			return "Hz";
+		case CSS_KHZ:
+			return "kHz";
+		case CSS_CAP:
+			return "cap";
+		case CSS_CH:
+			return "ch";
+		case CSS_FR:
+			return "fr";
+		case CSS_IC:
+			return "ic";
+		case CSS_LH:
+			return "lh";
+		case CSS_QUARTER_MM:
+			return "Q";
+		case CSS_REM:
+			return "rem";
+		case CSS_RLH:
+			return "rlh";
+		case CSS_REX:
+			return "rex";
+		case CSS_RCH:
+			return "rch";
+		case CSS_RIC:
+			return "ric";
+		case CSS_VB:
+			return "vb";
+		case CSS_VH:
+			return "vh";
+		case CSS_VI:
+			return "vi";
+		case CSS_VMAX:
+			return "vmax";
+		case CSS_VMIN:
+			return "vmin";
+		case CSS_VW:
+			return "vw";
+		case CSS_DPI:
+			return "dpi";
+		case CSS_DPCM:
+			return "dpcm";
+		case CSS_DPPX:
+			return "dppx";
+		case CSS_NUMBER:
+		case CSS_OTHER:
+		case CSS_INVALID:
+			return "";
+		default:
+			throw new DOMException(DOMException.INVALID_ACCESS_ERR, "Unknown unit: " + unitType);
+		}
+	}
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/unit/package-info.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/unit/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Support package about CSS units.
+ */
+package org.w3c.css.om.unit;

--- a/cssom-api/src/main/java/org/w3c/css/om/view/MediaQueryList.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/view/MediaQueryList.java
@@ -1,0 +1,90 @@
+/*
+ * This software extends interfaces defined by CSSOM View Module
+ * (https://www.w3.org/TR/cssom-view-1/).
+ * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ * 
+ * Copyright © 2017-2024, Carlos Amengual.
+ */
+/*
+ * SPDX-License-Identifier: W3C-20150513
+ */
+
+package org.w3c.css.om.view;
+
+import org.w3c.dom.DOMException;
+import org.w3c.dom.events.EventTarget;
+import org.w3c.dom.stylesheets.MediaList;
+
+/**
+ * Based on W3C's <a href=
+ * "https://www.w3.org/TR/cssom-view-1/#the-mediaquerylist-interface">MediaQueryList
+ * interface</a>.
+ * <p>
+ * For backwards compatibility, it extends the deprecated <code>MediaList</code>
+ * interface.
+ * </p>
+ */
+public interface MediaQueryList extends MediaList, EventTarget {
+
+	/**
+	 * Get the serialized form of this media query list.
+	 * 
+	 * @return the serialized form of this media query list.
+	 */
+	String getMedia();
+
+	/**
+	 * Get the serialized form of this media query list.
+	 * 
+	 * @return the serialized form of this media query list.
+	 * @deprecated use {@link #getMedia()}.
+	 */
+	@Deprecated
+	@Override
+	default String getMediaText() {
+		return getMedia();
+	}
+
+	/**
+	 * Sets the <code>media</code> attribute, which the current specification
+	 * defines to be read-only.
+	 * 
+	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR: Raised if this media list
+	 *                      is read-only.
+	 */
+	@Deprecated
+	@Override
+	default void setMediaText(String mediaText) throws DOMException {
+		throw new DOMException(DOMException.NO_MODIFICATION_ALLOWED_ERR, "This is a read-only attribute.");
+	}
+
+	/**
+	 * Deletes a medium from this list, which the current specification does not
+	 * support.
+	 * 
+	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR: Raised if this media list
+	 *                      is read-only.
+	 */
+	@Deprecated
+	@Override
+	default void deleteMedium(String oldMedium) throws DOMException {
+		throw new DOMException(DOMException.NO_MODIFICATION_ALLOWED_ERR,
+				"Media query lists cannot be modified this way.");
+	}
+
+	/**
+	 * Appends a medium to this list, which the current specification does not
+	 * support.
+	 * 
+	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR: Raised if this media list
+	 *                      is read-only.
+	 */
+	@Deprecated
+	@Override
+	default void appendMedium(String newMedium) throws DOMException {
+		throw new DOMException(DOMException.NO_MODIFICATION_ALLOWED_ERR,
+				"Media query lists cannot be modified this way.");
+	}
+
+}

--- a/cssom-api/src/main/java/org/w3c/css/om/view/package-info.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/view/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * <a href="https://www.w3.org/TR/cssom-view-1/">CSS Object Model View</a>.
+ */
+package org.w3c.css.om.view;

--- a/cssview-api/build.gradle
+++ b/cssview-api/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+	id 'web-apis.java-conventions'
+}
+
+description = 'io.sf.carte:cssview-api'
+
+version = '0.1'
+
+dependencies {
+	api project(':cssom-api')
+}
+
+publishing.publications.maven(MavenPublication).pom {
+	description = "CSS View 1.0-pre Java binding"
+}

--- a/cssview-api/src/main/java/module-info.java
+++ b/cssview-api/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018-2023 World Wide Web Consortium,
+ *
+ * (Massachusetts Institute of Technology, European Research Consortium for
+ * Informatics and Mathematics, Keio University). All Rights Reserved. This
+ * work is distributed under the W3C(r) Software License [1] in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+ * 
+ * Other copyrights:
+ * Copyright (c) 2020-2024, Carlos Amengual
+ */
+
+/**
+ * CSS legacy View Java binding.
+ */
+module org.w3c.css.view {
+
+	exports org.w3c.css.view;
+
+	requires transitive org.w3c.css.om;
+	requires jdk.xml.dom;
+	requires transitive java.xml;
+
+}

--- a/cssview-api/src/main/java/org/w3c/css/view/DocumentCSS.java
+++ b/cssview-api/src/main/java/org/w3c/css/view/DocumentCSS.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2000 World Wide Web Consortium,
+ * (Massachusetts Institute of Technology, Institut National de
+ * Recherche en Informatique et en Automatique, Keio University). All
+ * Rights Reserved. This program is distributed under the W3C's Software
+ * Intellectual Property License. This program is distributed in the
+ * hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ * See W3C License http://www.w3.org/Consortium/Legal/ for more details.
+ */
+/*
+ * SPDX-License-Identifier: W3C-19980720
+ */
+
+package org.w3c.css.view;
+
+import org.w3c.css.om.CSSStyleDeclaration;
+import org.w3c.dom.Element;
+import org.w3c.dom.stylesheets.DocumentStyle;
+
+/**
+ * This interface represents a document with a CSS view.
+ * <p>
+ * The <code>getOverrideStyle</code> method provides a mechanism through which a
+ * DOM author could effect immediate change to the style of an element without
+ * modifying the explicitly linked style sheets of a document or the inline
+ * style of elements in the style sheets. This style sheet comes after the
+ * author style sheet in the cascade algorithm and is called <em>override style
+ * sheet</em>. The override style sheet takes precedence over author style
+ * sheets. An "!important" declaration still takes precedence over a normal
+ * declaration. Override, author, and user style sheets all may contain
+ * "!important" declarations. User "!important" rules take precedence over both
+ * override and author "!important" rules, and override "!important" rules take
+ * precedence over author "!important" rules.
+ * <p>
+ * The expectation is that an instance of the <code>DocumentCSS</code> interface
+ * can be obtained by using binding-specific casting methods on an instance of
+ * the <code>Document</code> interface.
+ * <p>
+ * See the
+ * <a href='http://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113'>Document
+ * Object Model (DOM) Level 2 Style Specification</a>.
+ * 
+ * @deprecated This interface is no longer part of the DOM standard.
+ */
+@Deprecated
+public interface DocumentCSS extends DocumentStyle {
+
+	/**
+	 * This method is used to retrieve the override style declaration for a
+	 * specified element and a specified pseudo-element.
+	 * 
+	 * @param elt       The element whose style is to be modified. This parameter
+	 *                  cannot be <code>null</code>.
+	 * @param pseudoElt The pseudo-element or <code>null</code> if none.
+	 * @return The override style declaration.
+	 */
+	public CSSStyleDeclaration getOverrideStyle(Element elt, String pseudoElt);
+
+}

--- a/cssview-api/src/main/java/org/w3c/css/view/ViewCSS.java
+++ b/cssview-api/src/main/java/org/w3c/css/view/ViewCSS.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2000 World Wide Web Consortium,
+ * (Massachusetts Institute of Technology, Institut National de
+ * Recherche en Informatique et en Automatique, Keio University). All
+ * Rights Reserved. This program is distributed under the W3C's Software
+ * Intellectual Property License. This program is distributed in the
+ * hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ * See W3C License http://www.w3.org/Consortium/Legal/ for more details.
+ */
+/*
+ * SPDX-License-Identifier: W3C-19980720
+ */
+
+package org.w3c.css.view;
+
+import org.w3c.css.om.CSSStyleDeclaration;
+import org.w3c.dom.Element;
+import org.w3c.dom.views.AbstractView;
+
+/**
+ * This interface represents a CSS view. The <code>getComputedStyle</code>
+ * method provides a <b>read only access</b> to the computed values of an
+ * element.
+ * <p>
+ * The expectation is that an instance of the <code>ViewCSS</code> interface can
+ * be obtained by using binding-specific casting methods on an instance of the
+ * <code>AbstractView</code> interface.
+ * <p>
+ * Since a computed style is related to an <code>Element</code> node, if this
+ * element is removed from the document, the associated
+ * <code>CSSStyleDeclaration</code> and <code>CSSStyleValue</code> related to
+ * this declaration are no longer valid.
+ * <p>
+ * See the
+ * <a href="http://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113">Document
+ * Object Model (DOM) Level 2 Style Specification</a>.
+ * 
+ * @deprecated This interface is no longer part of the DOM standard.
+ */
+@Deprecated
+public interface ViewCSS extends AbstractView {
+
+	/**
+	 * This method is used to get the computed style as it is defined in
+	 * [<a href='http://www.w3.org/TR/1998/REC-CSS2-19980512'>CSS2</a>].
+	 * 
+	 * @param elt       The element whose style is to be computed. This parameter
+	 *                  cannot be null.
+	 * @param pseudoElt The pseudo-element or <code>null</code> if none.
+	 * @return The computed style. The <code>CSSStyleDeclaration</code> is read-only
+	 *         and contains only absolute values.
+	 */
+	public CSSStyleDeclaration getComputedStyle(Element elt, String pseudoElt);
+
+}

--- a/cssview-api/src/main/java/org/w3c/css/view/package-info.java
+++ b/cssview-api/src/main/java/org/w3c/css/view/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * CSS legacy DOM view.
+ */
+package org.w3c.css.view;

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,5 @@ rootProject.name = 'web-apis'
 
 include(':smil-api')
 include(':svgom-api')
+include(':cssom-api')
+include(':cssview-api')

--- a/svgom-api/build.gradle
+++ b/svgom-api/build.gradle
@@ -8,8 +8,8 @@ dependencies {
 
 description = 'io.sf.carte:svgom-api'
 
-version = '1.0.1'
+version = '1.1'
 
 publishing.publications.maven(MavenPublication).pom {
-	description = "SVGOM 1.0 API Java binding"
+	description = "SVGOM 1.1 API Java binding"
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGColor.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGColor.java
@@ -15,22 +15,33 @@ package org.w3c.dom.svg;
 import org.w3c.dom.css.CSSValue;
 import org.w3c.dom.css.RGBColor;
 
+/**
+ * Corresponds to color value definition for properties ‘stop-color’,
+ * ‘flood-color’ and ‘lighting-color’.
+ */
+@Deprecated(forRemoval = true)
 public interface SVGColor extends CSSValue {
+
 	// Color Types
-	public static final short SVG_COLORTYPE_UNKNOWN = 0;
-	public static final short SVG_COLORTYPE_RGBCOLOR = 1;
-	public static final short SVG_COLORTYPE_RGBCOLOR_ICCCOLOR = 2;
-	public static final short SVG_COLORTYPE_CURRENTCOLOR = 3;
+	short SVG_COLORTYPE_UNKNOWN = 0;
+	short SVG_COLORTYPE_RGBCOLOR = 1;
+	short SVG_COLORTYPE_RGBCOLOR_ICCCOLOR = 2;
+	short SVG_COLORTYPE_CURRENTCOLOR = 3;
 
-	public short getColorType();
+	short getColorType();
 
-	public RGBColor getRGBColor();
+	default RGBColor getRGBColor() {
+		return null;
+	}
 
-	public SVGICCColor getICCColor();
+	default SVGICCColor getICCColor() {
+		return null;
+	}
 
-	public void setRGBColor(String rgbColor) throws SVGException;
+	void setRGBColor(String rgbColor) throws SVGException;
 
-	public void setRGBColorICCColor(String rgbColor, String iccColor) throws SVGException;
+	void setRGBColorICCColor(String rgbColor, String iccColor) throws SVGException;
 
-	public void setColor(short colorType, String rgbColor, String iccColor) throws SVGException;
+	void setColor(short colorType, String rgbColor, String iccColor) throws SVGException;
+
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGICCColor.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGICCColor.java
@@ -14,6 +14,10 @@ package org.w3c.dom.svg;
 
 import org.w3c.dom.DOMException;
 
+/**
+ * Expresses an ICC-based color specification.
+ */
+@Deprecated(forRemoval = true)
 public interface SVGICCColor {
 	public String getColorProfile();
 

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPaint.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPaint.java
@@ -12,6 +12,11 @@
 
 package org.w3c.dom.svg;
 
+/**
+ * Corresponds to basic type <paint> and represents the values of properties
+ * ‘fill’ and ‘stroke’.
+ */
+@Deprecated
 public interface SVGPaint extends SVGColor {
 	// Paint Types
 	public static final short SVG_PAINTTYPE_UNKNOWN = 0;


### PR DESCRIPTION
Houdini's Typed OM API is hostile to strongly-typed languages (see the array/single-value duality) and lacks support for string values. This is a rough first (and likely last) attempt at a Java binding.

See #1.