### PR TITLE
Modify svgom-api to be compatible with Houdini's Typed OM

### DIFF
--- a/cssom-api/src/main/java/org/w3c/css/om/CSSRule.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSRule.java
@@ -1,14 +1,4 @@
 /*
- * Interfaces defined by CSS Typed Object Model draft
- *  (https://www.w3.org/TR/css-typed-om-1/).
- * Copyright © 2018-2023 W3C® (MIT, ERCIM, Keio, Beihang).
- * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
- */
-/*
- * SPDX-License-Identifier: W3C-20150513
- */
-package org.w3c.css.om;
-/*
  * This software extends interfaces defined by CSS Object Model draft
  *  (https://www.w3.org/TR/cssom-1/).
  * Copyright © 2016 W3C® (MIT, ERCIM, Keio, Beihang).
@@ -17,6 +7,7 @@ package org.w3c.css.om;
 /*
  * SPDX-License-Identifier: W3C-20150513
  */
+package org.w3c.css.om;
 
 /**
  * A CSS rule.

--- a/cssom-api/src/main/java/org/w3c/css/om/CSSStyleDeclaration.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/CSSStyleDeclaration.java
@@ -12,17 +12,19 @@ package org.w3c.css.om;
 
 import org.w3c.css.om.typed.CSSStyleValue;
 import org.w3c.dom.DOMException;
+import org.w3c.dom.css.CSSValue;
 
 /**
  * CSS style declaration.
  */
-public interface CSSStyleDeclaration {
+public interface CSSStyleDeclaration extends org.w3c.dom.css.CSSStyleDeclaration {
 
 	/**
 	 * A parsable serialization of the declaration.
 	 *
 	 * @return the textual representation of the declaration.
 	 */
+	@Override
 	String getCssText();
 
 	/**
@@ -31,6 +33,7 @@ public interface CSSStyleDeclaration {
 	 * 
 	 * @param cssText the serialized style declaration.
 	 */
+	@Override
 	void setCssText(String cssText) throws DOMException;
 
 	/**
@@ -40,6 +43,7 @@ public interface CSSStyleDeclaration {
 	 * @return the value of the removed property, or the empty string if that
 	 *         property was not explicitly set in this declaration.
 	 */
+	@Override
 	String removeProperty(String propertyName) throws DOMException;
 
 	/**
@@ -48,6 +52,7 @@ public interface CSSStyleDeclaration {
 	 * @param propertyName the name of the property.
 	 * @return the priority string, or the empty string if no priority was set.
 	 */
+	@Override
 	String getPropertyPriority(String propertyName);
 
 	/**
@@ -57,6 +62,7 @@ public interface CSSStyleDeclaration {
 	 * @param value the property value.
 	 * @param priority the priority.
 	 */
+	@Override
 	void setProperty(String propertyName, String value, String priority) throws DOMException;
 
 	/**
@@ -64,6 +70,7 @@ public interface CSSStyleDeclaration {
 	 * 
 	 * @return the number of properties in this declaration.
 	 */
+	@Override
 	int getLength();
 
 	/**
@@ -74,7 +81,30 @@ public interface CSSStyleDeclaration {
 	 *         less than zero, or greater or equal to the length of this
 	 *         declaration.
 	 */
+	@Override
 	String item(int index);
+
+	/**
+	 * Gives the legacy object representation of the value of a CSS property if it
+	 * has been explicitly set within this declaration block.
+	 * <p>
+	 * This method returns <code>null</code> if the property is a shorthand
+	 * property. Shorthand property values can only be accessed and modified as
+	 * strings, using the <code>getPropertyValue</code> and <code>setProperty</code>
+	 * methods.
+	 * </p>
+	 * 
+	 * @param propertyName The name of the CSS property.
+	 * @return the value of the property if it has been explicitly set for this
+	 *         declaration block. Returns <code>null</code> if the property has not
+	 *         been set, or the implementation does not support legacy object
+	 *         values.
+	 */
+	@SuppressWarnings("exports")
+	@Override
+	default CSSValue getPropertyCSSValue(String propertyName) {
+		return null;
+	}
 
 	/**
 	 * Gets the object representation of the value of a CSS property if it has been
@@ -109,6 +139,7 @@ public interface CSSStyleDeclaration {
 	 *         block, or the empty string if the property has not been set or is a shorthand
 	 *         that could not be serialized.
 	 */
+	@Override
 	String getPropertyValue(String propertyName);
 
 	/**
@@ -117,6 +148,7 @@ public interface CSSStyleDeclaration {
 	 * @return the CSS rule that contains this declaration block or <code>null</code> if this
 	 *         <code>CSSStyleDeclaration</code> is not attached to a <code>CSSRule</code>.
 	 */
+	@Override
 	CSSRule getParentRule();
 
 }

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSNumericValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSNumericValue.java
@@ -29,7 +29,7 @@ public interface CSSNumericValue extends CSSStyleValue {
 		flex,
 		/** &lt;percentage&gt; */
 		percent
-	};
+	}
 
 	/**
 	 * A "map" from types to powers.

--- a/cssom-api/src/main/java/org/w3c/css/om/typed/CSSStyleValue.java
+++ b/cssom-api/src/main/java/org/w3c/css/om/typed/CSSStyleValue.java
@@ -19,6 +19,7 @@ public interface CSSStyleValue {
 	 * 
 	 * @return a parsable representation of this value.
 	 */
+	@Override
 	String toString();
 
 }

--- a/svgom-api/build.gradle
+++ b/svgom-api/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
 	api project(':smil-api')
+	api project(':cssom-api')
 }
 
 description = 'io.sf.carte:svgom-api'

--- a/svgom-api/src/main/java/module-info.java
+++ b/svgom-api/src/main/java/module-info.java
@@ -10,15 +10,15 @@
  * [1] http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
  * 
  * Later modifications:
- * Copyright (c) 2020-2021 Carlos Amengual
+ * Copyright (c) 2020-2024 Carlos Amengual
  */
 
 /**
  * Scalable Vector Graphics (SVG) Java binding.
  * <p>
  * This is a Java binding for an old version of the SVG DOM API (SVGOM). It is
- * compatible with the SVGOM API used by Apache Batik (which uses the SVGOM
- * packages at the <a href=
+ * compatible with modern Typed OM but also with the legacy SVGOM API used by
+ * Apache Batik (which uses the SVGOM packages at the <a href=
  * "http://archive.apache.org/dist/xml/commons/xml-commons-external-1.3.04-src.zip">{@code xml-apis-ext-1.3.04}</a>
  * package), that seem to be a mixture of the
  * <a href="http://www.w3.org/TR/2000/CR-SVG-20000802/java-binding.zip">SVG
@@ -28,12 +28,15 @@
  * </p>
  * <p>
  * Some method signatures were modified so they match the implementations in
- * Apache Batik/EchoSVG.
+ * Apache Batik.
  * </p>
  */
 module org.w3c.dom.svg {
+
 	exports org.w3c.dom.svg;
 
 	requires transitive jdk.xml.dom;
 	requires transitive org.w3c.dom.smil;
+	requires transitive org.w3c.css.om;
+
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/GetSVGDocument.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/GetSVGDocument.java
@@ -15,5 +15,5 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface GetSVGDocument {
-	public SVGDocument getSVGDocument() throws DOMException;
+	SVGDocument getSVGDocument() throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAElement.java
@@ -16,5 +16,5 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGAElement extends SVGElement, SVGURIReference, SVGTests, SVGLangSpace, SVGExternalResourcesRequired,
 		SVGStylable, SVGTransformable, EventTarget {
-	public SVGAnimatedString getTarget();
+	SVGAnimatedString getTarget();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAltGlyphElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAltGlyphElement.java
@@ -15,11 +15,11 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGAltGlyphElement extends SVGTextPositioningElement, SVGURIReference {
-	public String getGlyphRef();
+	String getGlyphRef();
 
-	public void setGlyphRef(String glyphRef) throws DOMException;
+	void setGlyphRef(String glyphRef) throws DOMException;
 
-	public String getFormat();
+	String getFormat();
 
-	public void setFormat(String format) throws DOMException;
+	void setFormat(String format) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAngle.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAngle.java
@@ -16,27 +16,27 @@ import org.w3c.dom.DOMException;
 
 public interface SVGAngle {
 	// Angle Unit Types
-	public static final short SVG_ANGLETYPE_UNKNOWN = 0;
-	public static final short SVG_ANGLETYPE_UNSPECIFIED = 1;
-	public static final short SVG_ANGLETYPE_DEG = 2;
-	public static final short SVG_ANGLETYPE_RAD = 3;
-	public static final short SVG_ANGLETYPE_GRAD = 4;
+	short SVG_ANGLETYPE_UNKNOWN = 0;
+	short SVG_ANGLETYPE_UNSPECIFIED = 1;
+	short SVG_ANGLETYPE_DEG = 2;
+	short SVG_ANGLETYPE_RAD = 3;
+	short SVG_ANGLETYPE_GRAD = 4;
 
-	public short getUnitType();
+	short getUnitType();
 
-	public float getValue();
+	float getValue();
 
-	public void setValue(float value) throws DOMException;
+	void setValue(float value) throws DOMException;
 
-	public float getValueInSpecifiedUnits();
+	float getValueInSpecifiedUnits();
 
-	public void setValueInSpecifiedUnits(float valueInSpecifiedUnits) throws DOMException;
+	void setValueInSpecifiedUnits(float valueInSpecifiedUnits) throws DOMException;
 
-	public String getValueAsString();
+	String getValueAsString();
 
-	public void setValueAsString(String valueAsString) throws DOMException;
+	void setValueAsString(String valueAsString) throws DOMException;
 
-	public void newValueSpecifiedUnits(short unitType, float valueInSpecifiedUnits);
+	void newValueSpecifiedUnits(short unitType, float valueInSpecifiedUnits);
 
-	public void convertToSpecifiedUnits(short unitType);
+	void convertToSpecifiedUnits(short unitType);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedAngle.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedAngle.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGAnimatedAngle {
-	public SVGAngle getBaseVal();
+	SVGAngle getBaseVal();
 
-	public SVGAngle getAnimVal();
+	SVGAngle getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedBoolean.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedBoolean.java
@@ -15,9 +15,9 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGAnimatedBoolean {
-	public boolean getBaseVal();
+	boolean getBaseVal();
 
-	public void setBaseVal(boolean baseVal) throws DOMException;
+	void setBaseVal(boolean baseVal) throws DOMException;
 
-	public boolean getAnimVal();
+	boolean getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedEnumeration.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedEnumeration.java
@@ -15,9 +15,9 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGAnimatedEnumeration {
-	public short getBaseVal();
+	short getBaseVal();
 
-	public void setBaseVal(short baseVal) throws DOMException;
+	void setBaseVal(short baseVal) throws DOMException;
 
-	public short getAnimVal();
+	short getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedInteger.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedInteger.java
@@ -15,9 +15,9 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGAnimatedInteger {
-	public int getBaseVal();
+	int getBaseVal();
 
-	public void setBaseVal(int baseVal) throws DOMException;
+	void setBaseVal(int baseVal) throws DOMException;
 
-	public int getAnimVal();
+	int getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedLength.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedLength.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGAnimatedLength {
-	public SVGLength getBaseVal();
+	SVGLength getBaseVal();
 
-	public SVGLength getAnimVal();
+	SVGLength getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedLengthList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedLengthList.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGAnimatedLengthList {
-	public SVGLengthList getBaseVal();
+	SVGLengthList getBaseVal();
 
-	public SVGLengthList getAnimVal();
+	SVGLengthList getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedNumber.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedNumber.java
@@ -15,9 +15,9 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGAnimatedNumber {
-	public float getBaseVal();
+	float getBaseVal();
 
-	public void setBaseVal(float baseVal) throws DOMException;
+	void setBaseVal(float baseVal) throws DOMException;
 
-	public float getAnimVal();
+	float getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedNumberList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedNumberList.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGAnimatedNumberList {
-	public SVGNumberList getBaseVal();
+	SVGNumberList getBaseVal();
 
-	public SVGNumberList getAnimVal();
+	SVGNumberList getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedPathData.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedPathData.java
@@ -31,7 +31,7 @@ public interface SVGAnimatedPathData {
 	 * 
 	 * @return the base contents of the {@code d} attribute.
 	 */
-	public SVGPathSegList getPathSegList();
+	SVGPathSegList getPathSegList();
 
 	/**
 	 * Gets the normalized contents of the {@code d} attribute.
@@ -62,7 +62,7 @@ public interface SVGAnimatedPathData {
 	 * 
 	 * @return the normalized contents of the {@code d} attribute.
 	 */
-	public SVGPathSegList getNormalizedPathSegList();
+	SVGPathSegList getNormalizedPathSegList();
 
 	/**
 	 * Gets the current animated contents of the {@code d} attribute.
@@ -77,7 +77,7 @@ public interface SVGAnimatedPathData {
 	 * 
 	 * @return the current animated contents of the {@code d} attribute.
 	 */
-	public SVGPathSegList getAnimatedPathSegList();
+	SVGPathSegList getAnimatedPathSegList();
 
 	/**
 	 * Gets the normalized current animated contents of the {@code d} attribute.
@@ -100,6 +100,6 @@ public interface SVGAnimatedPathData {
 	 * 
 	 * @return the normalized current animated contents of the {@code d} attribute.
 	 */
-	public SVGPathSegList getAnimatedNormalizedPathSegList();
+	SVGPathSegList getAnimatedNormalizedPathSegList();
 
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedPoints.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedPoints.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGAnimatedPoints {
-	public SVGPointList getPoints();
+	SVGPointList getPoints();
 
-	public SVGPointList getAnimatedPoints();
+	SVGPointList getAnimatedPoints();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedPreserveAspectRatio.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedPreserveAspectRatio.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGAnimatedPreserveAspectRatio {
-	public SVGPreserveAspectRatio getBaseVal();
+	SVGPreserveAspectRatio getBaseVal();
 
-	public SVGPreserveAspectRatio getAnimVal();
+	SVGPreserveAspectRatio getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedRect.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedRect.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGAnimatedRect {
-	public SVGRect getBaseVal();
+	SVGRect getBaseVal();
 
-	public SVGRect getAnimVal();
+	SVGRect getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedString.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedString.java
@@ -15,9 +15,9 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGAnimatedString {
-	public String getBaseVal();
+	String getBaseVal();
 
-	public void setBaseVal(String baseVal) throws DOMException;
+	void setBaseVal(String baseVal) throws DOMException;
 
-	public String getAnimVal();
+	String getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedTransformList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimatedTransformList.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGAnimatedTransformList {
-	public SVGTransformList getBaseVal();
+	SVGTransformList getBaseVal();
 
-	public SVGTransformList getAnimVal();
+	SVGTransformList getAnimVal();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimationElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGAnimationElement.java
@@ -17,11 +17,11 @@ import org.w3c.dom.smil.ElementTimeControl;
 
 public interface SVGAnimationElement
 		extends SVGElement, SVGTests, SVGExternalResourcesRequired, ElementTimeControl, EventTarget {
-	public SVGElement getTargetElement();
+	SVGElement getTargetElement();
 
-	public float getStartTime();
+	float getStartTime();
 
-	public float getCurrentTime();
+	float getCurrentTime();
 
-	public float getSimpleDuration() throws DOMException;
+	float getSimpleDuration() throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGCSSRule.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGCSSRule.java
@@ -16,5 +16,5 @@ import org.w3c.dom.css.CSSRule;
 
 public interface SVGCSSRule extends CSSRule {
 	// Additional CSS RuleType to support ICC color specifications
-	public static final short COLOR_PROFILE_RULE = 7;
+	short COLOR_PROFILE_RULE = 7;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGCircleElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGCircleElement.java
@@ -16,9 +16,9 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGCircleElement extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable,
 		SVGTransformable, EventTarget {
-	public SVGAnimatedLength getCx();
+	SVGAnimatedLength getCx();
 
-	public SVGAnimatedLength getCy();
+	SVGAnimatedLength getCy();
 
-	public SVGAnimatedLength getR();
+	SVGAnimatedLength getR();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGClipPathElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGClipPathElement.java
@@ -14,5 +14,5 @@ package org.w3c.dom.svg;
 
 public interface SVGClipPathElement extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired,
 		SVGStylable, SVGTransformable, SVGUnitTypes {
-	public SVGAnimatedEnumeration getClipPathUnits();
+	SVGAnimatedEnumeration getClipPathUnits();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGColor.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGColor.java
@@ -34,6 +34,7 @@ public interface SVGColor extends CSSValue {
 		return null;
 	}
 
+	@SuppressWarnings("removal")
 	default SVGICCColor getICCColor() {
 		return null;
 	}

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGColorProfileElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGColorProfileElement.java
@@ -15,15 +15,15 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGColorProfileElement extends SVGElement, SVGURIReference, SVGRenderingIntent {
-	public String getLocal();
+	String getLocal();
 
-	public void setLocal(String local) throws DOMException;
+	void setLocal(String local) throws DOMException;
 
-	public String getName();
+	String getName();
 
-	public void setName(String name) throws DOMException;
+	void setName(String name) throws DOMException;
 
-	public short getRenderingIntent();
+	short getRenderingIntent();
 
-	public void setRenderingIntent(short renderingIntent) throws DOMException;
+	void setRenderingIntent(short renderingIntent) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGColorProfileRule.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGColorProfileRule.java
@@ -15,15 +15,15 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGColorProfileRule extends SVGCSSRule, SVGRenderingIntent {
-	public String getSrc();
+	String getSrc();
 
-	public void setSrc(String src) throws DOMException;
+	void setSrc(String src) throws DOMException;
 
-	public String getName();
+	String getName();
 
-	public void setName(String name) throws DOMException;
+	void setName(String name) throws DOMException;
 
-	public short getRenderingIntent();
+	short getRenderingIntent();
 
-	public void setRenderingIntent(short renderingIntent) throws DOMException;
+	void setRenderingIntent(short renderingIntent) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGComponentTransferFunctionElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGComponentTransferFunctionElement.java
@@ -14,24 +14,24 @@ package org.w3c.dom.svg;
 
 public interface SVGComponentTransferFunctionElement extends SVGElement {
 	// Component Transfer Types
-	public static final short SVG_FECOMPONENTTRANSFER_TYPE_UNKNOWN = 0;
-	public static final short SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY = 1;
-	public static final short SVG_FECOMPONENTTRANSFER_TYPE_TABLE = 2;
-	public static final short SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE = 3;
-	public static final short SVG_FECOMPONENTTRANSFER_TYPE_LINEAR = 4;
-	public static final short SVG_FECOMPONENTTRANSFER_TYPE_GAMMA = 5;
+	short SVG_FECOMPONENTTRANSFER_TYPE_UNKNOWN = 0;
+	short SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY = 1;
+	short SVG_FECOMPONENTTRANSFER_TYPE_TABLE = 2;
+	short SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE = 3;
+	short SVG_FECOMPONENTTRANSFER_TYPE_LINEAR = 4;
+	short SVG_FECOMPONENTTRANSFER_TYPE_GAMMA = 5;
 
-	public SVGAnimatedEnumeration getType();
+	SVGAnimatedEnumeration getType();
 
-	public SVGAnimatedNumberList getTableValues();
+	SVGAnimatedNumberList getTableValues();
 
-	public SVGAnimatedNumber getSlope();
+	SVGAnimatedNumber getSlope();
 
-	public SVGAnimatedNumber getIntercept();
+	SVGAnimatedNumber getIntercept();
 
-	public SVGAnimatedNumber getAmplitude();
+	SVGAnimatedNumber getAmplitude();
 
-	public SVGAnimatedNumber getExponent();
+	SVGAnimatedNumber getExponent();
 
-	public SVGAnimatedNumber getOffset();
+	SVGAnimatedNumber getOffset();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGCursorElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGCursorElement.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGCursorElement extends SVGElement, SVGURIReference, SVGTests, SVGExternalResourcesRequired {
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGDocument.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGDocument.java
@@ -16,13 +16,13 @@ import org.w3c.dom.Document;
 import org.w3c.dom.events.DocumentEvent;
 
 public interface SVGDocument extends Document, DocumentEvent {
-	public String getTitle();
+	String getTitle();
 
-	public String getReferrer();
+	String getReferrer();
 
-	public String getDomain();
+	String getDomain();
 
-	public String getURL();
+	String getURL();
 
-	public SVGSVGElement getRootElement();
+	SVGSVGElement getRootElement();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGElement.java
@@ -22,7 +22,7 @@ public interface SVGElement extends Element {
 	 * 
 	 * @return the value of the {@code id} attribute, or the empty string if none.
 	 */
-	public String getId();
+	String getId();
 
 	/**
 	 * Sets the {@code id} content attribute.
@@ -30,11 +30,11 @@ public interface SVGElement extends Element {
 	 * @param id the value of the {@code id} attribute.
 	 * @throws DOMException
 	 */
-	public void setId(String id) throws DOMException;
+	void setId(String id) throws DOMException;
 
-	public String getXMLbase();
+	String getXMLbase();
 
-	public void setXMLbase(String xmlbase) throws DOMException;
+	void setXMLbase(String xmlbase) throws DOMException;
 
 	/**
 	 * Gets the nearest ancestor {@code svg} element.
@@ -42,7 +42,7 @@ public interface SVGElement extends Element {
 	 * @return the nearest ancestor {@code svg} element, or {@code null} if the
 	 *         current element is the outermost {@code svg} element.
 	 */
-	public SVGSVGElement getOwnerSVGElement();
+	SVGSVGElement getOwnerSVGElement();
 
 	/**
 	 * Get the element that provides the SVG viewport for this element.
@@ -50,5 +50,5 @@ public interface SVGElement extends Element {
 	 * @return the nearest ancestor element that establishes an SVG viewport, or
 	 *         {@code null} if the current element is the outermost svg element.
 	 */
-	public SVGElement getViewportElement();
+	SVGElement getViewportElement();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGElementInstance.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGElementInstance.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.events.EventTarget;
 
 public interface SVGElementInstance extends EventTarget {
-	public SVGElement getCorrespondingElement();
+	SVGElement getCorrespondingElement();
 
-	public SVGUseElement getCorrespondingUseElement();
+	SVGUseElement getCorrespondingUseElement();
 
-	public SVGElementInstance getParentNode();
+	SVGElementInstance getParentNode();
 
-	public SVGElementInstanceList getChildNodes();
+	SVGElementInstanceList getChildNodes();
 
-	public SVGElementInstance getFirstChild();
+	SVGElementInstance getFirstChild();
 
-	public SVGElementInstance getLastChild();
+	SVGElementInstance getLastChild();
 
-	public SVGElementInstance getPreviousSibling();
+	SVGElementInstance getPreviousSibling();
 
-	public SVGElementInstance getNextSibling();
+	SVGElementInstance getNextSibling();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGElementInstanceList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGElementInstanceList.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGElementInstanceList {
-	public int getLength();
+	int getLength();
 
-	public SVGElementInstance item(int index);
+	SVGElementInstance item(int index);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGEllipseElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGEllipseElement.java
@@ -16,11 +16,11 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGEllipseElement extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired,
 		SVGStylable, SVGTransformable, EventTarget {
-	public SVGAnimatedLength getCx();
+	SVGAnimatedLength getCx();
 
-	public SVGAnimatedLength getCy();
+	SVGAnimatedLength getCy();
 
-	public SVGAnimatedLength getRx();
+	SVGAnimatedLength getRx();
 
-	public SVGAnimatedLength getRy();
+	SVGAnimatedLength getRy();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGExternalResourcesRequired.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGExternalResourcesRequired.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGExternalResourcesRequired {
-	public SVGAnimatedBoolean getExternalResourcesRequired();
+	SVGAnimatedBoolean getExternalResourcesRequired();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEBlendElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEBlendElement.java
@@ -14,16 +14,16 @@ package org.w3c.dom.svg;
 
 public interface SVGFEBlendElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
 	// Blend Mode Types
-	public static final short SVG_FEBLEND_MODE_UNKNOWN = 0;
-	public static final short SVG_FEBLEND_MODE_NORMAL = 1;
-	public static final short SVG_FEBLEND_MODE_MULTIPLY = 2;
-	public static final short SVG_FEBLEND_MODE_SCREEN = 3;
-	public static final short SVG_FEBLEND_MODE_DARKEN = 4;
-	public static final short SVG_FEBLEND_MODE_LIGHTEN = 5;
+	short SVG_FEBLEND_MODE_UNKNOWN = 0;
+	short SVG_FEBLEND_MODE_NORMAL = 1;
+	short SVG_FEBLEND_MODE_MULTIPLY = 2;
+	short SVG_FEBLEND_MODE_SCREEN = 3;
+	short SVG_FEBLEND_MODE_DARKEN = 4;
+	short SVG_FEBLEND_MODE_LIGHTEN = 5;
 
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 
-	public SVGAnimatedString getIn2();
+	SVGAnimatedString getIn2();
 
-	public SVGAnimatedEnumeration getMode();
+	SVGAnimatedEnumeration getMode();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEColorMatrixElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEColorMatrixElement.java
@@ -14,15 +14,15 @@ package org.w3c.dom.svg;
 
 public interface SVGFEColorMatrixElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
 	// Color Matrix Types
-	public static final short SVG_FECOLORMATRIX_TYPE_UNKNOWN = 0;
-	public static final short SVG_FECOLORMATRIX_TYPE_MATRIX = 1;
-	public static final short SVG_FECOLORMATRIX_TYPE_SATURATE = 2;
-	public static final short SVG_FECOLORMATRIX_TYPE_HUEROTATE = 3;
-	public static final short SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA = 4;
+	short SVG_FECOLORMATRIX_TYPE_UNKNOWN = 0;
+	short SVG_FECOLORMATRIX_TYPE_MATRIX = 1;
+	short SVG_FECOLORMATRIX_TYPE_SATURATE = 2;
+	short SVG_FECOLORMATRIX_TYPE_HUEROTATE = 3;
+	short SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA = 4;
 
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 
-	public SVGAnimatedEnumeration getType();
+	SVGAnimatedEnumeration getType();
 
-	public SVGAnimatedNumberList getValues();
+	SVGAnimatedNumberList getValues();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEComponentTransferElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEComponentTransferElement.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGFEComponentTransferElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFECompositeElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFECompositeElement.java
@@ -14,25 +14,25 @@ package org.w3c.dom.svg;
 
 public interface SVGFECompositeElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
 	// Composite Operators
-	public static final short SVG_FECOMPOSITE_OPERATOR_UNKNOWN = 0;
-	public static final short SVG_FECOMPOSITE_OPERATOR_OVER = 1;
-	public static final short SVG_FECOMPOSITE_OPERATOR_IN = 2;
-	public static final short SVG_FECOMPOSITE_OPERATOR_OUT = 3;
-	public static final short SVG_FECOMPOSITE_OPERATOR_ATOP = 4;
-	public static final short SVG_FECOMPOSITE_OPERATOR_XOR = 5;
-	public static final short SVG_FECOMPOSITE_OPERATOR_ARITHMETIC = 6;
+	short SVG_FECOMPOSITE_OPERATOR_UNKNOWN = 0;
+	short SVG_FECOMPOSITE_OPERATOR_OVER = 1;
+	short SVG_FECOMPOSITE_OPERATOR_IN = 2;
+	short SVG_FECOMPOSITE_OPERATOR_OUT = 3;
+	short SVG_FECOMPOSITE_OPERATOR_ATOP = 4;
+	short SVG_FECOMPOSITE_OPERATOR_XOR = 5;
+	short SVG_FECOMPOSITE_OPERATOR_ARITHMETIC = 6;
 
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 
-	public SVGAnimatedString getIn2();
+	SVGAnimatedString getIn2();
 
-	public SVGAnimatedEnumeration getOperator();
+	SVGAnimatedEnumeration getOperator();
 
-	public SVGAnimatedNumber getK1();
+	SVGAnimatedNumber getK1();
 
-	public SVGAnimatedNumber getK2();
+	SVGAnimatedNumber getK2();
 
-	public SVGAnimatedNumber getK3();
+	SVGAnimatedNumber getK3();
 
-	public SVGAnimatedNumber getK4();
+	SVGAnimatedNumber getK4();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEConvolveMatrixElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEConvolveMatrixElement.java
@@ -14,30 +14,30 @@ package org.w3c.dom.svg;
 
 public interface SVGFEConvolveMatrixElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
 	// Edge Mode Values
-	public static final short SVG_EDGEMODE_UNKNOWN = 0;
-	public static final short SVG_EDGEMODE_DUPLICATE = 1;
-	public static final short SVG_EDGEMODE_WRAP = 2;
-	public static final short SVG_EDGEMODE_NONE = 3;
+	short SVG_EDGEMODE_UNKNOWN = 0;
+	short SVG_EDGEMODE_DUPLICATE = 1;
+	short SVG_EDGEMODE_WRAP = 2;
+	short SVG_EDGEMODE_NONE = 3;
 
-	public SVGAnimatedInteger getOrderX();
+	SVGAnimatedInteger getOrderX();
 
-	public SVGAnimatedInteger getOrderY();
+	SVGAnimatedInteger getOrderY();
 
-	public SVGAnimatedNumberList getKernelMatrix();
+	SVGAnimatedNumberList getKernelMatrix();
 
-	public SVGAnimatedNumber getDivisor();
+	SVGAnimatedNumber getDivisor();
 
-	public SVGAnimatedNumber getBias();
+	SVGAnimatedNumber getBias();
 
-	public SVGAnimatedInteger getTargetX();
+	SVGAnimatedInteger getTargetX();
 
-	public SVGAnimatedInteger getTargetY();
+	SVGAnimatedInteger getTargetY();
 
-	public SVGAnimatedEnumeration getEdgeMode();
+	SVGAnimatedEnumeration getEdgeMode();
 
-	public SVGAnimatedNumber getKernelUnitLengthX();
+	SVGAnimatedNumber getKernelUnitLengthX();
 
-	public SVGAnimatedNumber getKernelUnitLengthY();
+	SVGAnimatedNumber getKernelUnitLengthY();
 
-	public SVGAnimatedBoolean getPreserveAlpha();
+	SVGAnimatedBoolean getPreserveAlpha();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEDisplacementMapElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEDisplacementMapElement.java
@@ -14,19 +14,19 @@ package org.w3c.dom.svg;
 
 public interface SVGFEDisplacementMapElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
 	// Channel Selectors
-	public static final short SVG_CHANNEL_UNKNOWN = 0;
-	public static final short SVG_CHANNEL_R = 1;
-	public static final short SVG_CHANNEL_G = 2;
-	public static final short SVG_CHANNEL_B = 3;
-	public static final short SVG_CHANNEL_A = 4;
+	short SVG_CHANNEL_UNKNOWN = 0;
+	short SVG_CHANNEL_R = 1;
+	short SVG_CHANNEL_G = 2;
+	short SVG_CHANNEL_B = 3;
+	short SVG_CHANNEL_A = 4;
 
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 
-	public SVGAnimatedString getIn2();
+	SVGAnimatedString getIn2();
 
-	public SVGAnimatedNumber getScale();
+	SVGAnimatedNumber getScale();
 
-	public SVGAnimatedEnumeration getXChannelSelector();
+	SVGAnimatedEnumeration getXChannelSelector();
 
-	public SVGAnimatedEnumeration getYChannelSelector();
+	SVGAnimatedEnumeration getYChannelSelector();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEDistantLightElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEDistantLightElement.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGFEDistantLightElement extends SVGElement {
-	public SVGAnimatedNumber getAzimuth();
+	SVGAnimatedNumber getAzimuth();
 
-	public SVGAnimatedNumber getElevation();
+	SVGAnimatedNumber getElevation();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEFloodElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEFloodElement.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGFEFloodElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEGaussianBlurElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEGaussianBlurElement.java
@@ -13,11 +13,11 @@
 package org.w3c.dom.svg;
 
 public interface SVGFEGaussianBlurElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 
-	public SVGAnimatedNumber getStdDeviationX();
+	SVGAnimatedNumber getStdDeviationX();
 
-	public SVGAnimatedNumber getStdDeviationY();
+	SVGAnimatedNumber getStdDeviationY();
 
-	public void setStdDeviation(float stdDeviationX, float stdDeviationY);
+	void setStdDeviation(float stdDeviationX, float stdDeviationY);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEMergeNodeElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEMergeNodeElement.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGFEMergeNodeElement extends SVGElement {
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEMorphologyElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEMorphologyElement.java
@@ -14,15 +14,15 @@ package org.w3c.dom.svg;
 
 public interface SVGFEMorphologyElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
 	// Morphology Operators
-	public static final short SVG_MORPHOLOGY_OPERATOR_UNKNOWN = 0;
-	public static final short SVG_MORPHOLOGY_OPERATOR_ERODE = 1;
-	public static final short SVG_MORPHOLOGY_OPERATOR_DILATE = 2;
+	short SVG_MORPHOLOGY_OPERATOR_UNKNOWN = 0;
+	short SVG_MORPHOLOGY_OPERATOR_ERODE = 1;
+	short SVG_MORPHOLOGY_OPERATOR_DILATE = 2;
 
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 
-	public SVGAnimatedEnumeration getOperator();
+	SVGAnimatedEnumeration getOperator();
 
-	public SVGAnimatedNumber getRadiusX();
+	SVGAnimatedNumber getRadiusX();
 
-	public SVGAnimatedNumber getRadiusY();
+	SVGAnimatedNumber getRadiusY();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEOffsetElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEOffsetElement.java
@@ -13,9 +13,9 @@
 package org.w3c.dom.svg;
 
 public interface SVGFEOffsetElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 
-	public SVGAnimatedNumber getDx();
+	SVGAnimatedNumber getDx();
 
-	public SVGAnimatedNumber getDy();
+	SVGAnimatedNumber getDy();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEPointLightElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFEPointLightElement.java
@@ -13,9 +13,9 @@
 package org.w3c.dom.svg;
 
 public interface SVGFEPointLightElement extends SVGElement {
-	public SVGAnimatedNumber getX();
+	SVGAnimatedNumber getX();
 
-	public SVGAnimatedNumber getY();
+	SVGAnimatedNumber getY();
 
-	public SVGAnimatedNumber getZ();
+	SVGAnimatedNumber getZ();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFESpecularLightingElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFESpecularLightingElement.java
@@ -13,11 +13,11 @@
 package org.w3c.dom.svg;
 
 public interface SVGFESpecularLightingElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 
-	public SVGAnimatedNumber getSurfaceScale();
+	SVGAnimatedNumber getSurfaceScale();
 
-	public SVGAnimatedNumber getSpecularConstant();
+	SVGAnimatedNumber getSpecularConstant();
 
-	public SVGAnimatedNumber getSpecularExponent();
+	SVGAnimatedNumber getSpecularExponent();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFESpotLightElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFESpotLightElement.java
@@ -13,19 +13,19 @@
 package org.w3c.dom.svg;
 
 public interface SVGFESpotLightElement extends SVGElement {
-	public SVGAnimatedNumber getX();
+	SVGAnimatedNumber getX();
 
-	public SVGAnimatedNumber getY();
+	SVGAnimatedNumber getY();
 
-	public SVGAnimatedNumber getZ();
+	SVGAnimatedNumber getZ();
 
-	public SVGAnimatedNumber getPointsAtX();
+	SVGAnimatedNumber getPointsAtX();
 
-	public SVGAnimatedNumber getPointsAtY();
+	SVGAnimatedNumber getPointsAtY();
 
-	public SVGAnimatedNumber getPointsAtZ();
+	SVGAnimatedNumber getPointsAtZ();
 
-	public SVGAnimatedNumber getSpecularExponent();
+	SVGAnimatedNumber getSpecularExponent();
 
-	public SVGAnimatedNumber getLimitingConeAngle();
+	SVGAnimatedNumber getLimitingConeAngle();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFETileElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFETileElement.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGFETileElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
-	public SVGAnimatedString getIn1();
+	SVGAnimatedString getIn1();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFETurbulenceElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFETurbulenceElement.java
@@ -14,23 +14,23 @@ package org.w3c.dom.svg;
 
 public interface SVGFETurbulenceElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
 	// Turbulence Types
-	public static final short SVG_TURBULENCE_TYPE_UNKNOWN = 0;
-	public static final short SVG_TURBULENCE_TYPE_FRACTALNOISE = 1;
-	public static final short SVG_TURBULENCE_TYPE_TURBULENCE = 2;
+	short SVG_TURBULENCE_TYPE_UNKNOWN = 0;
+	short SVG_TURBULENCE_TYPE_FRACTALNOISE = 1;
+	short SVG_TURBULENCE_TYPE_TURBULENCE = 2;
 	// Stitch Options
-	public static final short SVG_STITCHTYPE_UNKNOWN = 0;
-	public static final short SVG_STITCHTYPE_STITCH = 1;
-	public static final short SVG_STITCHTYPE_NOSTITCH = 2;
+	short SVG_STITCHTYPE_UNKNOWN = 0;
+	short SVG_STITCHTYPE_STITCH = 1;
+	short SVG_STITCHTYPE_NOSTITCH = 2;
 
-	public SVGAnimatedNumber getBaseFrequencyX();
+	SVGAnimatedNumber getBaseFrequencyX();
 
-	public SVGAnimatedNumber getBaseFrequencyY();
+	SVGAnimatedNumber getBaseFrequencyY();
 
-	public SVGAnimatedInteger getNumOctaves();
+	SVGAnimatedInteger getNumOctaves();
 
-	public SVGAnimatedNumber getSeed();
+	SVGAnimatedNumber getSeed();
 
-	public SVGAnimatedEnumeration getStitchTiles();
+	SVGAnimatedEnumeration getStitchTiles();
 
-	public SVGAnimatedEnumeration getType();
+	SVGAnimatedEnumeration getType();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFilterElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFilterElement.java
@@ -14,21 +14,21 @@ package org.w3c.dom.svg;
 
 public interface SVGFilterElement
 		extends SVGElement, SVGURIReference, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable, SVGUnitTypes {
-	public SVGAnimatedEnumeration getFilterUnits();
+	SVGAnimatedEnumeration getFilterUnits();
 
-	public SVGAnimatedEnumeration getPrimitiveUnits();
+	SVGAnimatedEnumeration getPrimitiveUnits();
 
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 
-	public SVGAnimatedInteger getFilterResX();
+	SVGAnimatedInteger getFilterResX();
 
-	public SVGAnimatedInteger getFilterResY();
+	SVGAnimatedInteger getFilterResY();
 
-	public void setFilterRes(int filterResX, int filterResY);
+	void setFilterRes(int filterResX, int filterResY);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFilterPrimitiveStandardAttributes.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFilterPrimitiveStandardAttributes.java
@@ -13,13 +13,13 @@
 package org.w3c.dom.svg;
 
 public interface SVGFilterPrimitiveStandardAttributes extends SVGStylable {
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 
-	public SVGAnimatedString getResult();
+	SVGAnimatedString getResult();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGFitToViewBox.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGFitToViewBox.java
@@ -13,7 +13,7 @@
 package org.w3c.dom.svg;
 
 public interface SVGFitToViewBox {
-	public SVGAnimatedRect getViewBox();
+	SVGAnimatedRect getViewBox();
 
-	public SVGAnimatedPreserveAspectRatio getPreserveAspectRatio();
+	SVGAnimatedPreserveAspectRatio getPreserveAspectRatio();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGForeignObjectElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGForeignObjectElement.java
@@ -16,11 +16,11 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGForeignObjectElement extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired,
 		SVGStylable, SVGTransformable, EventTarget {
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGGlyphRefElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGGlyphRefElement.java
@@ -15,27 +15,27 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGGlyphRefElement extends SVGElement, SVGURIReference, SVGStylable {
-	public String getGlyphRef();
+	String getGlyphRef();
 
-	public void setGlyphRef(String glyphRef) throws DOMException;
+	void setGlyphRef(String glyphRef) throws DOMException;
 
-	public String getFormat();
+	String getFormat();
 
-	public void setFormat(String format) throws DOMException;
+	void setFormat(String format) throws DOMException;
 
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getDx();
+	float getDx();
 
-	public void setDx(float dx) throws DOMException;
+	void setDx(float dx) throws DOMException;
 
-	public float getDy();
+	float getDy();
 
-	public void setDy(float dy) throws DOMException;
+	void setDy(float dy) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGGradientElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGGradientElement.java
@@ -15,14 +15,14 @@ package org.w3c.dom.svg;
 public interface SVGGradientElement
 		extends SVGElement, SVGURIReference, SVGExternalResourcesRequired, SVGStylable, SVGUnitTypes {
 	// Spread Method Types
-	public static final short SVG_SPREADMETHOD_UNKNOWN = 0;
-	public static final short SVG_SPREADMETHOD_PAD = 1;
-	public static final short SVG_SPREADMETHOD_REFLECT = 2;
-	public static final short SVG_SPREADMETHOD_REPEAT = 3;
+	short SVG_SPREADMETHOD_UNKNOWN = 0;
+	short SVG_SPREADMETHOD_PAD = 1;
+	short SVG_SPREADMETHOD_REFLECT = 2;
+	short SVG_SPREADMETHOD_REPEAT = 3;
 
-	public SVGAnimatedEnumeration getGradientUnits();
+	SVGAnimatedEnumeration getGradientUnits();
 
-	public SVGAnimatedTransformList getGradientTransform();
+	SVGAnimatedTransformList getGradientTransform();
 
-	public SVGAnimatedEnumeration getSpreadMethod();
+	SVGAnimatedEnumeration getSpreadMethod();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGICCColor.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGICCColor.java
@@ -19,9 +19,9 @@ import org.w3c.dom.DOMException;
  */
 @Deprecated(forRemoval = true)
 public interface SVGICCColor {
-	public String getColorProfile();
+	String getColorProfile();
 
-	public void setColorProfile(String colorProfile) throws DOMException;
+	void setColorProfile(String colorProfile) throws DOMException;
 
-	public SVGNumberList getColors();
+	SVGNumberList getColors();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGImageElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGImageElement.java
@@ -16,13 +16,13 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGImageElement extends SVGElement, SVGURIReference, SVGTests, SVGLangSpace,
 		SVGExternalResourcesRequired, SVGStylable, SVGTransformable, EventTarget {
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 
-	public SVGAnimatedPreserveAspectRatio getPreserveAspectRatio();
+	SVGAnimatedPreserveAspectRatio getPreserveAspectRatio();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGLangSpace.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGLangSpace.java
@@ -15,11 +15,11 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGLangSpace {
-	public String getXMLlang();
+	String getXMLlang();
 
-	public void setXMLlang(String xmllang) throws DOMException;
+	void setXMLlang(String xmllang) throws DOMException;
 
-	public String getXMLspace();
+	String getXMLspace();
 
-	public void setXMLspace(String xmlspace) throws DOMException;
+	void setXMLspace(String xmlspace) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGLength.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGLength.java
@@ -16,33 +16,33 @@ import org.w3c.dom.DOMException;
 
 public interface SVGLength {
 	// Length Unit Types
-	public static final short SVG_LENGTHTYPE_UNKNOWN = 0;
-	public static final short SVG_LENGTHTYPE_NUMBER = 1;
-	public static final short SVG_LENGTHTYPE_PERCENTAGE = 2;
-	public static final short SVG_LENGTHTYPE_EMS = 3;
-	public static final short SVG_LENGTHTYPE_EXS = 4;
-	public static final short SVG_LENGTHTYPE_PX = 5;
-	public static final short SVG_LENGTHTYPE_CM = 6;
-	public static final short SVG_LENGTHTYPE_MM = 7;
-	public static final short SVG_LENGTHTYPE_IN = 8;
-	public static final short SVG_LENGTHTYPE_PT = 9;
-	public static final short SVG_LENGTHTYPE_PC = 10;
+	short SVG_LENGTHTYPE_UNKNOWN = 0;
+	short SVG_LENGTHTYPE_NUMBER = 1;
+	short SVG_LENGTHTYPE_PERCENTAGE = 2;
+	short SVG_LENGTHTYPE_EMS = 3;
+	short SVG_LENGTHTYPE_EXS = 4;
+	short SVG_LENGTHTYPE_PX = 5;
+	short SVG_LENGTHTYPE_CM = 6;
+	short SVG_LENGTHTYPE_MM = 7;
+	short SVG_LENGTHTYPE_IN = 8;
+	short SVG_LENGTHTYPE_PT = 9;
+	short SVG_LENGTHTYPE_PC = 10;
 
-	public short getUnitType();
+	short getUnitType();
 
-	public float getValue();
+	float getValue();
 
-	public void setValue(float value) throws DOMException;
+	void setValue(float value) throws DOMException;
 
-	public float getValueInSpecifiedUnits();
+	float getValueInSpecifiedUnits();
 
-	public void setValueInSpecifiedUnits(float valueInSpecifiedUnits) throws DOMException;
+	void setValueInSpecifiedUnits(float valueInSpecifiedUnits) throws DOMException;
 
-	public String getValueAsString();
+	String getValueAsString();
 
-	public void setValueAsString(String valueAsString) throws DOMException;
+	void setValueAsString(String valueAsString) throws DOMException;
 
-	public void newValueSpecifiedUnits(short unitType, float valueInSpecifiedUnits);
+	void newValueSpecifiedUnits(short unitType, float valueInSpecifiedUnits);
 
-	public void convertToSpecifiedUnits(short unitType);
+	void convertToSpecifiedUnits(short unitType);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGLengthList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGLengthList.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGLengthList {
-	public int getNumberOfItems();
+	int getNumberOfItems();
 
-	public void clear() throws DOMException;
+	void clear() throws DOMException;
 
-	public SVGLength initialize(SVGLength newItem) throws DOMException, SVGException;
+	SVGLength initialize(SVGLength newItem) throws DOMException, SVGException;
 
-	public SVGLength getItem(int index) throws DOMException;
+	SVGLength getItem(int index) throws DOMException;
 
-	public SVGLength insertItemBefore(SVGLength newItem, int index) throws DOMException, SVGException;
+	SVGLength insertItemBefore(SVGLength newItem, int index) throws DOMException, SVGException;
 
-	public SVGLength replaceItem(SVGLength newItem, int index) throws DOMException, SVGException;
+	SVGLength replaceItem(SVGLength newItem, int index) throws DOMException, SVGException;
 
-	public SVGLength removeItem(int index) throws DOMException;
+	SVGLength removeItem(int index) throws DOMException;
 
-	public SVGLength appendItem(SVGLength newItem) throws DOMException, SVGException;
+	SVGLength appendItem(SVGLength newItem) throws DOMException, SVGException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGLineElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGLineElement.java
@@ -16,11 +16,11 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGLineElement extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable,
 		SVGTransformable, EventTarget {
-	public SVGAnimatedLength getX1();
+	SVGAnimatedLength getX1();
 
-	public SVGAnimatedLength getY1();
+	SVGAnimatedLength getY1();
 
-	public SVGAnimatedLength getX2();
+	SVGAnimatedLength getX2();
 
-	public SVGAnimatedLength getY2();
+	SVGAnimatedLength getY2();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGLinearGradientElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGLinearGradientElement.java
@@ -13,11 +13,11 @@
 package org.w3c.dom.svg;
 
 public interface SVGLinearGradientElement extends SVGGradientElement {
-	public SVGAnimatedLength getX1();
+	SVGAnimatedLength getX1();
 
-	public SVGAnimatedLength getY1();
+	SVGAnimatedLength getY1();
 
-	public SVGAnimatedLength getX2();
+	SVGAnimatedLength getX2();
 
-	public SVGAnimatedLength getY2();
+	SVGAnimatedLength getY2();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGLocatable.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGLocatable.java
@@ -13,15 +13,15 @@
 package org.w3c.dom.svg;
 
 public interface SVGLocatable {
-	public SVGElement getNearestViewportElement();
+	SVGElement getNearestViewportElement();
 
-	public SVGElement getFarthestViewportElement();
+	SVGElement getFarthestViewportElement();
 
-	public SVGRect getBBox();
+	SVGRect getBBox();
 
-	public SVGMatrix getCTM();
+	SVGMatrix getCTM();
 
-	public SVGMatrix getScreenCTM();
+	SVGMatrix getScreenCTM();
 
-	public SVGMatrix getTransformToElement(SVGElement element) throws SVGException;
+	SVGMatrix getTransformToElement(SVGElement element) throws SVGException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGMarkerElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGMarkerElement.java
@@ -15,29 +15,29 @@ package org.w3c.dom.svg;
 public interface SVGMarkerElement
 		extends SVGElement, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable, SVGFitToViewBox {
 	// Marker Unit Types
-	public static final short SVG_MARKERUNITS_UNKNOWN = 0;
-	public static final short SVG_MARKERUNITS_USERSPACEONUSE = 1;
-	public static final short SVG_MARKERUNITS_STROKEWIDTH = 2;
+	short SVG_MARKERUNITS_UNKNOWN = 0;
+	short SVG_MARKERUNITS_USERSPACEONUSE = 1;
+	short SVG_MARKERUNITS_STROKEWIDTH = 2;
 	// Marker Orientation Types
-	public static final short SVG_MARKER_ORIENT_UNKNOWN = 0;
-	public static final short SVG_MARKER_ORIENT_AUTO = 1;
-	public static final short SVG_MARKER_ORIENT_ANGLE = 2;
+	short SVG_MARKER_ORIENT_UNKNOWN = 0;
+	short SVG_MARKER_ORIENT_AUTO = 1;
+	short SVG_MARKER_ORIENT_ANGLE = 2;
 
-	public SVGAnimatedLength getRefX();
+	SVGAnimatedLength getRefX();
 
-	public SVGAnimatedLength getRefY();
+	SVGAnimatedLength getRefY();
 
-	public SVGAnimatedEnumeration getMarkerUnits();
+	SVGAnimatedEnumeration getMarkerUnits();
 
-	public SVGAnimatedLength getMarkerWidth();
+	SVGAnimatedLength getMarkerWidth();
 
-	public SVGAnimatedLength getMarkerHeight();
+	SVGAnimatedLength getMarkerHeight();
 
-	public SVGAnimatedEnumeration getOrientType();
+	SVGAnimatedEnumeration getOrientType();
 
-	public SVGAnimatedAngle getOrientAngle();
+	SVGAnimatedAngle getOrientAngle();
 
-	public void setOrientToAuto();
+	void setOrientToAuto();
 
-	public void setOrientToAngle(SVGAngle angle);
+	void setOrientToAngle(SVGAngle angle);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGMaskElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGMaskElement.java
@@ -14,15 +14,15 @@ package org.w3c.dom.svg;
 
 public interface SVGMaskElement
 		extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable, SVGUnitTypes {
-	public SVGAnimatedEnumeration getMaskUnits();
+	SVGAnimatedEnumeration getMaskUnits();
 
-	public SVGAnimatedEnumeration getMaskContentUnits();
+	SVGAnimatedEnumeration getMaskContentUnits();
 
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGMatrix.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGMatrix.java
@@ -38,7 +38,7 @@ public interface SVGMatrix {
 	/**
 	 * @return the {@code a} component of the matrix.
 	 */
-	public float getA();
+	float getA();
 
 	/**
 	 * Set the {@code a} component of the matrix.
@@ -47,12 +47,12 @@ public interface SVGMatrix {
 	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR on an attempt to change the
 	 *                      value of a read only attribute.
 	 */
-	public void setA(float a) throws DOMException;
+	void setA(float a) throws DOMException;
 
 	/**
 	 * @return the {@code b} component of the matrix.
 	 */
-	public float getB();
+	float getB();
 
 	/**
 	 * Set the {@code b} component of the matrix.
@@ -61,12 +61,12 @@ public interface SVGMatrix {
 	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR on an attempt to change the
 	 *                      value of a read only attribute.
 	 */
-	public void setB(float b) throws DOMException;
+	void setB(float b) throws DOMException;
 
 	/**
 	 * @return the {@code c} component of the matrix.
 	 */
-	public float getC();
+	float getC();
 
 	/**
 	 * Set the {@code c} component of the matrix.
@@ -75,12 +75,12 @@ public interface SVGMatrix {
 	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR on an attempt to change the
 	 *                      value of a read only attribute.
 	 */
-	public void setC(float c) throws DOMException;
+	void setC(float c) throws DOMException;
 
 	/**
 	 * @return the {@code d} component of the matrix.
 	 */
-	public float getD();
+	float getD();
 
 	/**
 	 * Set the {@code d} component of the matrix.
@@ -89,12 +89,12 @@ public interface SVGMatrix {
 	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR on an attempt to change the
 	 *                      value of a read only attribute.
 	 */
-	public void setD(float d) throws DOMException;
+	void setD(float d) throws DOMException;
 
 	/**
 	 * @return the {@code e} component of the matrix.
 	 */
-	public float getE();
+	float getE();
 
 	/**
 	 * Set the {@code e} component of the matrix.
@@ -103,12 +103,12 @@ public interface SVGMatrix {
 	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR on an attempt to change the
 	 *                      value of a read only attribute.
 	 */
-	public void setE(float e) throws DOMException;
+	void setE(float e) throws DOMException;
 
 	/**
 	 * @return the {@code f} component of the matrix.
 	 */
-	public float getF();
+	float getF();
 
 	/**
 	 * Set the {@code f} component of the matrix.
@@ -117,7 +117,7 @@ public interface SVGMatrix {
 	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR on an attempt to change the
 	 *                      value of a read only attribute.
 	 */
-	public void setF(float f) throws DOMException;
+	void setF(float f) throws DOMException;
 
 	/**
 	 * Performs matrix multiplication. This matrix is post-multiplied by another
@@ -126,14 +126,14 @@ public interface SVGMatrix {
 	 * @param secondMatrix the matrix which is post-multiplied to this matrix.
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix multiply(SVGMatrix secondMatrix);
+	SVGMatrix multiply(SVGMatrix secondMatrix);
 
 	/**
 	 * @return the inverse matrix.
 	 * @throws SVGException SVG_MATRIX_NOT_INVERTABLE if this matrix is not
 	 *                      invertible.
 	 */
-	public SVGMatrix inverse() throws SVGException;
+	SVGMatrix inverse() throws SVGException;
 
 	/**
 	 * Post-multiplies a translation transformation on the current matrix and
@@ -143,7 +143,7 @@ public interface SVGMatrix {
 	 * @param y the distance to translate along the y-axis.
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix translate(float x, float y);
+	SVGMatrix translate(float x, float y);
 
 	/**
 	 * Post-multiplies a uniform scale transformation on the current matrix and
@@ -152,7 +152,7 @@ public interface SVGMatrix {
 	 * @param scaleFactor the scale factor in both X and Y.
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix scale(float scaleFactor);
+	SVGMatrix scale(float scaleFactor);
 
 	/**
 	 * Post-multiplies a non-uniform scale transformation on the current matrix and
@@ -162,7 +162,7 @@ public interface SVGMatrix {
 	 * @param scaleFactorY the scale factor in Y.
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix scaleNonUniform(float scaleFactorX, float scaleFactorY);
+	SVGMatrix scaleNonUniform(float scaleFactorX, float scaleFactorY);
 
 	/**
 	 * Post-multiplies a rotation transformation on the current matrix and returns
@@ -171,7 +171,7 @@ public interface SVGMatrix {
 	 * @param angle the rotation angle.
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix rotate(float angle);
+	SVGMatrix rotate(float angle);
 
 	/**
 	 * Post-multiplies a rotation transformation on the current matrix and returns
@@ -185,7 +185,7 @@ public interface SVGMatrix {
 	 * @throws SVGException SVG_INVALID_VALUE_ERR if one of the parameters is an
 	 *                      invalid value.
 	 */
-	public SVGMatrix rotateFromVector(float x, float y) throws SVGException;
+	SVGMatrix rotateFromVector(float x, float y) throws SVGException;
 
 	/**
 	 * Post-multiplies the transformation {@code [-1 0 0 1 0 0]} and returns the
@@ -193,7 +193,7 @@ public interface SVGMatrix {
 	 * 
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix flipX();
+	SVGMatrix flipX();
 
 	/**
 	 * Post-multiplies the transformation {@code [1 0 0 -1 0 0]} and returns the
@@ -201,7 +201,7 @@ public interface SVGMatrix {
 	 * 
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix flipY();
+	SVGMatrix flipY();
 
 	/**
 	 * Post-multiplies a skewX transformation on the current matrix and returns the
@@ -210,7 +210,7 @@ public interface SVGMatrix {
 	 * @param angle the skew angle.
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix skewX(float angle);
+	SVGMatrix skewX(float angle);
 
 	/**
 	 * Post-multiplies a skewY transformation on the current matrix and returns the
@@ -219,6 +219,6 @@ public interface SVGMatrix {
 	 * @param angle the skew angle.
 	 * @return the resulting matrix.
 	 */
-	public SVGMatrix skewY(float angle);
+	SVGMatrix skewY(float angle);
 
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGNumber.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGNumber.java
@@ -15,7 +15,7 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGNumber {
-	public float getValue();
+	float getValue();
 
-	public void setValue(float value) throws DOMException;
+	void setValue(float value) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGNumberList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGNumberList.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGNumberList {
-	public int getNumberOfItems();
+	int getNumberOfItems();
 
-	public void clear() throws DOMException;
+	void clear() throws DOMException;
 
-	public SVGNumber initialize(SVGNumber newItem) throws DOMException, SVGException;
+	SVGNumber initialize(SVGNumber newItem) throws DOMException, SVGException;
 
-	public SVGNumber getItem(int index) throws DOMException;
+	SVGNumber getItem(int index) throws DOMException;
 
-	public SVGNumber insertItemBefore(SVGNumber newItem, int index) throws DOMException, SVGException;
+	SVGNumber insertItemBefore(SVGNumber newItem, int index) throws DOMException, SVGException;
 
-	public SVGNumber replaceItem(SVGNumber newItem, int index) throws DOMException, SVGException;
+	SVGNumber replaceItem(SVGNumber newItem, int index) throws DOMException, SVGException;
 
-	public SVGNumber removeItem(int index) throws DOMException;
+	SVGNumber removeItem(int index) throws DOMException;
 
-	public SVGNumber appendItem(SVGNumber newItem) throws DOMException, SVGException;
+	SVGNumber appendItem(SVGNumber newItem) throws DOMException, SVGException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPaint.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPaint.java
@@ -17,6 +17,7 @@ package org.w3c.dom.svg;
  * ‘fill’ and ‘stroke’.
  */
 @Deprecated
+@SuppressWarnings("removal")
 public interface SVGPaint extends SVGColor {
 	// Paint Types
 	public static final short SVG_PAINTTYPE_UNKNOWN = 0;

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPaint.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPaint.java
@@ -20,22 +20,22 @@ package org.w3c.dom.svg;
 @SuppressWarnings("removal")
 public interface SVGPaint extends SVGColor {
 	// Paint Types
-	public static final short SVG_PAINTTYPE_UNKNOWN = 0;
-	public static final short SVG_PAINTTYPE_RGBCOLOR = 1;
-	public static final short SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR = 2;
-	public static final short SVG_PAINTTYPE_NONE = 101;
-	public static final short SVG_PAINTTYPE_CURRENTCOLOR = 102;
-	public static final short SVG_PAINTTYPE_URI_NONE = 103;
-	public static final short SVG_PAINTTYPE_URI_CURRENTCOLOR = 104;
-	public static final short SVG_PAINTTYPE_URI_RGBCOLOR = 105;
-	public static final short SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR = 106;
-	public static final short SVG_PAINTTYPE_URI = 107;
+	short SVG_PAINTTYPE_UNKNOWN = 0;
+	short SVG_PAINTTYPE_RGBCOLOR = 1;
+	short SVG_PAINTTYPE_RGBCOLOR_ICCCOLOR = 2;
+	short SVG_PAINTTYPE_NONE = 101;
+	short SVG_PAINTTYPE_CURRENTCOLOR = 102;
+	short SVG_PAINTTYPE_URI_NONE = 103;
+	short SVG_PAINTTYPE_URI_CURRENTCOLOR = 104;
+	short SVG_PAINTTYPE_URI_RGBCOLOR = 105;
+	short SVG_PAINTTYPE_URI_RGBCOLOR_ICCCOLOR = 106;
+	short SVG_PAINTTYPE_URI = 107;
 
-	public short getPaintType();
+	short getPaintType();
 
-	public String getUri();
+	String getUri();
 
-	public void setUri(String uri);
+	void setUri(String uri);
 
-	public void setPaint(short paintType, String uri, String rgbColor, String iccColor) throws SVGException;
+	void setPaint(short paintType, String uri, String rgbColor, String iccColor) throws SVGException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathElement.java
@@ -16,53 +16,53 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGPathElement extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable,
 		SVGTransformable, EventTarget, SVGAnimatedPathData {
-	public SVGAnimatedNumber getPathLength();
+	SVGAnimatedNumber getPathLength();
 
-	public float getTotalLength();
+	float getTotalLength();
 
-	public SVGPoint getPointAtLength(float distance);
+	SVGPoint getPointAtLength(float distance);
 
-	public int getPathSegAtLength(float distance);
+	int getPathSegAtLength(float distance);
 
-	public SVGPathSegClosePath createSVGPathSegClosePath();
+	SVGPathSegClosePath createSVGPathSegClosePath();
 
-	public SVGPathSegMovetoAbs createSVGPathSegMovetoAbs(float x, float y);
+	SVGPathSegMovetoAbs createSVGPathSegMovetoAbs(float x, float y);
 
-	public SVGPathSegMovetoRel createSVGPathSegMovetoRel(float x, float y);
+	SVGPathSegMovetoRel createSVGPathSegMovetoRel(float x, float y);
 
-	public SVGPathSegLinetoAbs createSVGPathSegLinetoAbs(float x, float y);
+	SVGPathSegLinetoAbs createSVGPathSegLinetoAbs(float x, float y);
 
-	public SVGPathSegLinetoRel createSVGPathSegLinetoRel(float x, float y);
+	SVGPathSegLinetoRel createSVGPathSegLinetoRel(float x, float y);
 
-	public SVGPathSegCurvetoCubicAbs createSVGPathSegCurvetoCubicAbs(float x, float y, float x1, float y1, float x2,
+	SVGPathSegCurvetoCubicAbs createSVGPathSegCurvetoCubicAbs(float x, float y, float x1, float y1, float x2,
 			float y2);
 
-	public SVGPathSegCurvetoCubicRel createSVGPathSegCurvetoCubicRel(float x, float y, float x1, float y1, float x2,
+	SVGPathSegCurvetoCubicRel createSVGPathSegCurvetoCubicRel(float x, float y, float x1, float y1, float x2,
 			float y2);
 
-	public SVGPathSegCurvetoQuadraticAbs createSVGPathSegCurvetoQuadraticAbs(float x, float y, float x1, float y1);
+	SVGPathSegCurvetoQuadraticAbs createSVGPathSegCurvetoQuadraticAbs(float x, float y, float x1, float y1);
 
-	public SVGPathSegCurvetoQuadraticRel createSVGPathSegCurvetoQuadraticRel(float x, float y, float x1, float y1);
+	SVGPathSegCurvetoQuadraticRel createSVGPathSegCurvetoQuadraticRel(float x, float y, float x1, float y1);
 
-	public SVGPathSegArcAbs createSVGPathSegArcAbs(float x, float y, float r1, float r2, float angle,
+	SVGPathSegArcAbs createSVGPathSegArcAbs(float x, float y, float r1, float r2, float angle,
 			boolean largeArcFlag, boolean sweepFlag);
 
-	public SVGPathSegArcRel createSVGPathSegArcRel(float x, float y, float r1, float r2, float angle,
+	SVGPathSegArcRel createSVGPathSegArcRel(float x, float y, float r1, float r2, float angle,
 			boolean largeArcFlag, boolean sweepFlag);
 
-	public SVGPathSegLinetoHorizontalAbs createSVGPathSegLinetoHorizontalAbs(float x);
+	SVGPathSegLinetoHorizontalAbs createSVGPathSegLinetoHorizontalAbs(float x);
 
-	public SVGPathSegLinetoHorizontalRel createSVGPathSegLinetoHorizontalRel(float x);
+	SVGPathSegLinetoHorizontalRel createSVGPathSegLinetoHorizontalRel(float x);
 
-	public SVGPathSegLinetoVerticalAbs createSVGPathSegLinetoVerticalAbs(float y);
+	SVGPathSegLinetoVerticalAbs createSVGPathSegLinetoVerticalAbs(float y);
 
-	public SVGPathSegLinetoVerticalRel createSVGPathSegLinetoVerticalRel(float y);
+	SVGPathSegLinetoVerticalRel createSVGPathSegLinetoVerticalRel(float y);
 
-	public SVGPathSegCurvetoCubicSmoothAbs createSVGPathSegCurvetoCubicSmoothAbs(float x, float y, float x2, float y2);
+	SVGPathSegCurvetoCubicSmoothAbs createSVGPathSegCurvetoCubicSmoothAbs(float x, float y, float x2, float y2);
 
-	public SVGPathSegCurvetoCubicSmoothRel createSVGPathSegCurvetoCubicSmoothRel(float x, float y, float x2, float y2);
+	SVGPathSegCurvetoCubicSmoothRel createSVGPathSegCurvetoCubicSmoothRel(float x, float y, float x2, float y2);
 
-	public SVGPathSegCurvetoQuadraticSmoothAbs createSVGPathSegCurvetoQuadraticSmoothAbs(float x, float y);
+	SVGPathSegCurvetoQuadraticSmoothAbs createSVGPathSegCurvetoQuadraticSmoothAbs(float x, float y);
 
-	public SVGPathSegCurvetoQuadraticSmoothRel createSVGPathSegCurvetoQuadraticSmoothRel(float x, float y);
+	SVGPathSegCurvetoQuadraticSmoothRel createSVGPathSegCurvetoQuadraticSmoothRel(float x, float y);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSeg.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSeg.java
@@ -24,102 +24,102 @@ public interface SVGPathSeg {
 	 * define a new value of this type or to attempt to switch an existing value to
 	 * this type.
 	 */
-	public static final short PATHSEG_UNKNOWN = 0;
+	short PATHSEG_UNKNOWN = 0;
 
 	/**
 	 * {@code closepath} ({@code z}) path data command.
 	 */
-	public static final short PATHSEG_CLOSEPATH = 1;
+	short PATHSEG_CLOSEPATH = 1;
 
 	/**
 	 * {@code absolute moveto} ({@code M}) path data command.
 	 */
-	public static final short PATHSEG_MOVETO_ABS = 2;
+	short PATHSEG_MOVETO_ABS = 2;
 
 	/**
 	 * {@code relative moveto} ({@code m}) path data command.
 	 */
-	public static final short PATHSEG_MOVETO_REL = 3;
+	short PATHSEG_MOVETO_REL = 3;
 
 	/**
 	 * {@code absolute lineto} ({@code L}) path data command.
 	 */
-	public static final short PATHSEG_LINETO_ABS = 4;
+	short PATHSEG_LINETO_ABS = 4;
 
 	/**
 	 * {@code relative lineto} ({@code l}) path data command.
 	 */
-	public static final short PATHSEG_LINETO_REL = 5;
+	short PATHSEG_LINETO_REL = 5;
 
 	/**
 	 * {@code absolute cubic Bézier curveto} ({@code C}) path data command.
 	 */
-	public static final short PATHSEG_CURVETO_CUBIC_ABS = 6;
+	short PATHSEG_CURVETO_CUBIC_ABS = 6;
 
 	/**
 	 * {@code relative cubic Bézier curveto} ({@code c}) path data command.
 	 */
-	public static final short PATHSEG_CURVETO_CUBIC_REL = 7;
+	short PATHSEG_CURVETO_CUBIC_REL = 7;
 
 	/**
 	 * {@code absolute quadratic Bézier curveto} ({@code Q}) path data command.
 	 */
-	public static final short PATHSEG_CURVETO_QUADRATIC_ABS = 8;
+	short PATHSEG_CURVETO_QUADRATIC_ABS = 8;
 
 	/**
 	 * {@code relative quadratic Bézier curveto} ({@code q}) path data command.
 	 */
-	public static final short PATHSEG_CURVETO_QUADRATIC_REL = 9;
+	short PATHSEG_CURVETO_QUADRATIC_REL = 9;
 
 	/**
 	 * {@code absolute arcto} ({@code A}) path data command.
 	 */
-	public static final short PATHSEG_ARC_ABS = 10;
+	short PATHSEG_ARC_ABS = 10;
 
 	/**
 	 * {@code relative arcto} ({@code a}) path data command.
 	 */
-	public static final short PATHSEG_ARC_REL = 11;
+	short PATHSEG_ARC_REL = 11;
 
 	/**
 	 * {@code absolute horizontal lineto} ({@code H}) path data command.
 	 */
-	public static final short PATHSEG_LINETO_HORIZONTAL_ABS = 12;
+	short PATHSEG_LINETO_HORIZONTAL_ABS = 12;
 
 	/**
 	 * {@code relative horizontal lineto} ({@code h}) path data command.
 	 */
-	public static final short PATHSEG_LINETO_HORIZONTAL_REL = 13;
+	short PATHSEG_LINETO_HORIZONTAL_REL = 13;
 
 	/**
 	 * {@code absolute vertical lineto} ({@code V}) path data command.
 	 */
-	public static final short PATHSEG_LINETO_VERTICAL_ABS = 14;
+	short PATHSEG_LINETO_VERTICAL_ABS = 14;
 
 	/**
 	 * {@code relative vertical lineto} ({@code v}) path data command.
 	 */
-	public static final short PATHSEG_LINETO_VERTICAL_REL = 15;
+	short PATHSEG_LINETO_VERTICAL_REL = 15;
 
 	/**
 	 * {@code absolute smooth cubic curveto} ({@code S}) path data command.
 	 */
-	public static final short PATHSEG_CURVETO_CUBIC_SMOOTH_ABS = 16;
+	short PATHSEG_CURVETO_CUBIC_SMOOTH_ABS = 16;
 
 	/**
 	 * {@code relative smooth cubic curveto} ({@code s}) path data command.
 	 */
-	public static final short PATHSEG_CURVETO_CUBIC_SMOOTH_REL = 17;
+	short PATHSEG_CURVETO_CUBIC_SMOOTH_REL = 17;
 
 	/**
 	 * {@code absolute smooth quadratic curveto} ({@code T}) path data command.
 	 */
-	public static final short PATHSEG_CURVETO_QUADRATIC_SMOOTH_ABS = 18;
+	short PATHSEG_CURVETO_QUADRATIC_SMOOTH_ABS = 18;
 
 	/**
 	 * {@code relative smooth quadratic curveto} ({@code t}) path data command.
 	 */
-	public static final short PATHSEG_CURVETO_QUADRATIC_SMOOTH_REL = 19;
+	short PATHSEG_CURVETO_QUADRATIC_SMOOTH_REL = 19;
 
 	/**
 	 * Gets the type of the path segment as specified by one of the constants
@@ -127,7 +127,7 @@ public interface SVGPathSeg {
 	 * 
 	 * @return the type of the path segment.
 	 */
-	public short getPathSegType();
+	short getPathSegType();
 
 	/**
 	 * Gets the type of the path segment, specified by the corresponding
@@ -135,5 +135,5 @@ public interface SVGPathSeg {
 	 * 
 	 * @return the type of the path segment.
 	 */
-	public String getPathSegTypeAsLetter();
+	String getPathSegTypeAsLetter();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegArcAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegArcAbs.java
@@ -15,31 +15,31 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegArcAbs extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getR1();
+	float getR1();
 
-	public void setR1(float r1) throws DOMException;
+	void setR1(float r1) throws DOMException;
 
-	public float getR2();
+	float getR2();
 
-	public void setR2(float r2) throws DOMException;
+	void setR2(float r2) throws DOMException;
 
-	public float getAngle();
+	float getAngle();
 
-	public void setAngle(float angle) throws DOMException;
+	void setAngle(float angle) throws DOMException;
 
-	public boolean getLargeArcFlag();
+	boolean getLargeArcFlag();
 
-	public void setLargeArcFlag(boolean largeArcFlag) throws DOMException;
+	void setLargeArcFlag(boolean largeArcFlag) throws DOMException;
 
-	public boolean getSweepFlag();
+	boolean getSweepFlag();
 
-	public void setSweepFlag(boolean sweepFlag) throws DOMException;
+	void setSweepFlag(boolean sweepFlag) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegArcRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegArcRel.java
@@ -15,31 +15,31 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegArcRel extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getR1();
+	float getR1();
 
-	public void setR1(float r1) throws DOMException;
+	void setR1(float r1) throws DOMException;
 
-	public float getR2();
+	float getR2();
 
-	public void setR2(float r2) throws DOMException;
+	void setR2(float r2) throws DOMException;
 
-	public float getAngle();
+	float getAngle();
 
-	public void setAngle(float angle) throws DOMException;
+	void setAngle(float angle) throws DOMException;
 
-	public boolean getLargeArcFlag();
+	boolean getLargeArcFlag();
 
-	public void setLargeArcFlag(boolean largeArcFlag) throws DOMException;
+	void setLargeArcFlag(boolean largeArcFlag) throws DOMException;
 
-	public boolean getSweepFlag();
+	boolean getSweepFlag();
 
-	public void setSweepFlag(boolean sweepFlag) throws DOMException;
+	void setSweepFlag(boolean sweepFlag) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoCubicAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoCubicAbs.java
@@ -15,27 +15,27 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegCurvetoCubicAbs extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getX1();
+	float getX1();
 
-	public void setX1(float x1) throws DOMException;
+	void setX1(float x1) throws DOMException;
 
-	public float getY1();
+	float getY1();
 
-	public void setY1(float y1) throws DOMException;
+	void setY1(float y1) throws DOMException;
 
-	public float getX2();
+	float getX2();
 
-	public void setX2(float x2) throws DOMException;
+	void setX2(float x2) throws DOMException;
 
-	public float getY2();
+	float getY2();
 
-	public void setY2(float y2) throws DOMException;
+	void setY2(float y2) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoCubicRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoCubicRel.java
@@ -15,27 +15,27 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegCurvetoCubicRel extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getX1();
+	float getX1();
 
-	public void setX1(float x1) throws DOMException;
+	void setX1(float x1) throws DOMException;
 
-	public float getY1();
+	float getY1();
 
-	public void setY1(float y1) throws DOMException;
+	void setY1(float y1) throws DOMException;
 
-	public float getX2();
+	float getX2();
 
-	public void setX2(float x2) throws DOMException;
+	void setX2(float x2) throws DOMException;
 
-	public float getY2();
+	float getY2();
 
-	public void setY2(float y2) throws DOMException;
+	void setY2(float y2) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoCubicSmoothAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoCubicSmoothAbs.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegCurvetoCubicSmoothAbs extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getX2();
+	float getX2();
 
-	public void setX2(float x2) throws DOMException;
+	void setX2(float x2) throws DOMException;
 
-	public float getY2();
+	float getY2();
 
-	public void setY2(float y2) throws DOMException;
+	void setY2(float y2) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoCubicSmoothRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoCubicSmoothRel.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegCurvetoCubicSmoothRel extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getX2();
+	float getX2();
 
-	public void setX2(float x2) throws DOMException;
+	void setX2(float x2) throws DOMException;
 
-	public float getY2();
+	float getY2();
 
-	public void setY2(float y2) throws DOMException;
+	void setY2(float y2) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoQuadraticAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoQuadraticAbs.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegCurvetoQuadraticAbs extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getX1();
+	float getX1();
 
-	public void setX1(float x1) throws DOMException;
+	void setX1(float x1) throws DOMException;
 
-	public float getY1();
+	float getY1();
 
-	public void setY1(float y1) throws DOMException;
+	void setY1(float y1) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoQuadraticRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoQuadraticRel.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegCurvetoQuadraticRel extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public float getX1();
+	float getX1();
 
-	public void setX1(float x1) throws DOMException;
+	void setX1(float x1) throws DOMException;
 
-	public float getY1();
+	float getY1();
 
-	public void setY1(float y1) throws DOMException;
+	void setY1(float y1) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoQuadraticSmoothAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoQuadraticSmoothAbs.java
@@ -15,11 +15,11 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegCurvetoQuadraticSmoothAbs extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoQuadraticSmoothRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegCurvetoQuadraticSmoothRel.java
@@ -15,11 +15,11 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegCurvetoQuadraticSmoothRel extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoAbs.java
@@ -15,11 +15,11 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegLinetoAbs extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoHorizontalAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoHorizontalAbs.java
@@ -15,7 +15,7 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegLinetoHorizontalAbs extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoHorizontalRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoHorizontalRel.java
@@ -15,7 +15,7 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegLinetoHorizontalRel extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoRel.java
@@ -15,11 +15,11 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegLinetoRel extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoVerticalAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoVerticalAbs.java
@@ -15,7 +15,7 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegLinetoVerticalAbs extends SVGPathSeg {
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoVerticalRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegLinetoVerticalRel.java
@@ -15,7 +15,7 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegLinetoVerticalRel extends SVGPathSeg {
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegList.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegList {
-	public int getNumberOfItems();
+	int getNumberOfItems();
 
-	public void clear() throws DOMException;
+	void clear() throws DOMException;
 
-	public SVGPathSeg initialize(SVGPathSeg newItem) throws DOMException, SVGException;
+	SVGPathSeg initialize(SVGPathSeg newItem) throws DOMException, SVGException;
 
-	public SVGPathSeg getItem(int index) throws DOMException;
+	SVGPathSeg getItem(int index) throws DOMException;
 
-	public SVGPathSeg insertItemBefore(SVGPathSeg newItem, int index) throws DOMException, SVGException;
+	SVGPathSeg insertItemBefore(SVGPathSeg newItem, int index) throws DOMException, SVGException;
 
-	public SVGPathSeg replaceItem(SVGPathSeg newItem, int index) throws DOMException, SVGException;
+	SVGPathSeg replaceItem(SVGPathSeg newItem, int index) throws DOMException, SVGException;
 
-	public SVGPathSeg removeItem(int index) throws DOMException;
+	SVGPathSeg removeItem(int index) throws DOMException;
 
-	public SVGPathSeg appendItem(SVGPathSeg newItem) throws DOMException, SVGException;
+	SVGPathSeg appendItem(SVGPathSeg newItem) throws DOMException, SVGException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegMovetoAbs.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegMovetoAbs.java
@@ -15,11 +15,11 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegMovetoAbs extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegMovetoRel.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPathSegMovetoRel.java
@@ -15,11 +15,11 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPathSegMovetoRel extends SVGPathSeg {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPatternElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPatternElement.java
@@ -14,17 +14,17 @@ package org.w3c.dom.svg;
 
 public interface SVGPatternElement extends SVGElement, SVGURIReference, SVGTests, SVGLangSpace,
 		SVGExternalResourcesRequired, SVGStylable, SVGFitToViewBox, SVGUnitTypes {
-	public SVGAnimatedEnumeration getPatternUnits();
+	SVGAnimatedEnumeration getPatternUnits();
 
-	public SVGAnimatedEnumeration getPatternContentUnits();
+	SVGAnimatedEnumeration getPatternContentUnits();
 
-	public SVGAnimatedTransformList getPatternTransform();
+	SVGAnimatedTransformList getPatternTransform();
 
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPoint.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPoint.java
@@ -15,13 +15,13 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPoint {
-	public float getX();
+	float getX();
 
-	public void setX(float x) throws DOMException;
+	void setX(float x) throws DOMException;
 
-	public float getY();
+	float getY();
 
-	public void setY(float y) throws DOMException;
+	void setY(float y) throws DOMException;
 
-	public SVGPoint matrixTransform(SVGMatrix matrix);
+	SVGPoint matrixTransform(SVGMatrix matrix);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPointList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPointList.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGPointList {
-	public int getNumberOfItems();
+	int getNumberOfItems();
 
-	public void clear() throws DOMException;
+	void clear() throws DOMException;
 
-	public SVGPoint initialize(SVGPoint newItem) throws DOMException, SVGException;
+	SVGPoint initialize(SVGPoint newItem) throws DOMException, SVGException;
 
-	public SVGPoint getItem(int index) throws DOMException;
+	SVGPoint getItem(int index) throws DOMException;
 
-	public SVGPoint insertItemBefore(SVGPoint newItem, int index) throws DOMException, SVGException;
+	SVGPoint insertItemBefore(SVGPoint newItem, int index) throws DOMException, SVGException;
 
-	public SVGPoint replaceItem(SVGPoint newItem, int index) throws DOMException, SVGException;
+	SVGPoint replaceItem(SVGPoint newItem, int index) throws DOMException, SVGException;
 
-	public SVGPoint removeItem(int index) throws DOMException;
+	SVGPoint removeItem(int index) throws DOMException;
 
-	public SVGPoint appendItem(SVGPoint newItem) throws DOMException, SVGException;
+	SVGPoint appendItem(SVGPoint newItem) throws DOMException, SVGException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGPreserveAspectRatio.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGPreserveAspectRatio.java
@@ -16,27 +16,27 @@ import org.w3c.dom.DOMException;
 
 public interface SVGPreserveAspectRatio {
 	// Alignment Types
-	public static final short SVG_PRESERVEASPECTRATIO_UNKNOWN = 0;
-	public static final short SVG_PRESERVEASPECTRATIO_NONE = 1;
-	public static final short SVG_PRESERVEASPECTRATIO_XMINYMIN = 2;
-	public static final short SVG_PRESERVEASPECTRATIO_XMIDYMIN = 3;
-	public static final short SVG_PRESERVEASPECTRATIO_XMAXYMIN = 4;
-	public static final short SVG_PRESERVEASPECTRATIO_XMINYMID = 5;
-	public static final short SVG_PRESERVEASPECTRATIO_XMIDYMID = 6;
-	public static final short SVG_PRESERVEASPECTRATIO_XMAXYMID = 7;
-	public static final short SVG_PRESERVEASPECTRATIO_XMINYMAX = 8;
-	public static final short SVG_PRESERVEASPECTRATIO_XMIDYMAX = 9;
-	public static final short SVG_PRESERVEASPECTRATIO_XMAXYMAX = 10;
+	short SVG_PRESERVEASPECTRATIO_UNKNOWN = 0;
+	short SVG_PRESERVEASPECTRATIO_NONE = 1;
+	short SVG_PRESERVEASPECTRATIO_XMINYMIN = 2;
+	short SVG_PRESERVEASPECTRATIO_XMIDYMIN = 3;
+	short SVG_PRESERVEASPECTRATIO_XMAXYMIN = 4;
+	short SVG_PRESERVEASPECTRATIO_XMINYMID = 5;
+	short SVG_PRESERVEASPECTRATIO_XMIDYMID = 6;
+	short SVG_PRESERVEASPECTRATIO_XMAXYMID = 7;
+	short SVG_PRESERVEASPECTRATIO_XMINYMAX = 8;
+	short SVG_PRESERVEASPECTRATIO_XMIDYMAX = 9;
+	short SVG_PRESERVEASPECTRATIO_XMAXYMAX = 10;
 	// Meet-or-slice Types
-	public static final short SVG_MEETORSLICE_UNKNOWN = 0;
-	public static final short SVG_MEETORSLICE_MEET = 1;
-	public static final short SVG_MEETORSLICE_SLICE = 2;
+	short SVG_MEETORSLICE_UNKNOWN = 0;
+	short SVG_MEETORSLICE_MEET = 1;
+	short SVG_MEETORSLICE_SLICE = 2;
 
-	public short getAlign();
+	short getAlign();
 
-	public void setAlign(short align) throws DOMException;
+	void setAlign(short align) throws DOMException;
 
-	public short getMeetOrSlice();
+	short getMeetOrSlice();
 
-	public void setMeetOrSlice(short meetOrSlice) throws DOMException;
+	void setMeetOrSlice(short meetOrSlice) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGRadialGradientElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGRadialGradientElement.java
@@ -13,13 +13,13 @@
 package org.w3c.dom.svg;
 
 public interface SVGRadialGradientElement extends SVGGradientElement {
-	public SVGAnimatedLength getCx();
+	SVGAnimatedLength getCx();
 
-	public SVGAnimatedLength getCy();
+	SVGAnimatedLength getCy();
 
-	public SVGAnimatedLength getR();
+	SVGAnimatedLength getR();
 
-	public SVGAnimatedLength getFx();
+	SVGAnimatedLength getFx();
 
-	public SVGAnimatedLength getFy();
+	SVGAnimatedLength getFy();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGRect.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGRect.java
@@ -14,20 +14,82 @@ package org.w3c.dom.svg;
 
 import org.w3c.dom.DOMException;
 
+/**
+ * Represents rectangular geometry.
+ * <p>
+ * Rectangles are defined as consisting of a (x,y) coordinate pair identifying a
+ * minimum X value, a minimum Y value, and a width and height, which are usually
+ * constrained to be non-negative.
+ * </p>
+ */
 public interface SVGRect {
-	public float getX();
 
-	public void setX(float x) throws DOMException;
+	/**
+	 * The minimum X value.
+	 * 
+	 * @return the minimum X value in user units.
+	 */
+	float getX();
 
-	public float getY();
+	/**
+	 * Sets the minimum X value.
+	 * 
+	 * @param x the minimum X value in user units.
+	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR if the rectangle corresponds
+	 *                      to a read only attribute or when the object itself is
+	 *                      read only.
+	 */
+	void setX(float x) throws DOMException;
 
-	public void setY(float y) throws DOMException;
+	/**
+	 * The minimum Y value.
+	 * 
+	 * @return the minimum Y value in user units.
+	 */
+	float getY();
 
-	public float getWidth();
+	/**
+	 * Sets the minimum Y value.
+	 * 
+	 * @param y the minimum Y value in user units.
+	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR if the rectangle corresponds
+	 *                      to a read only attribute or when the object itself is
+	 *                      read only.
+	 */
+	void setY(float y) throws DOMException;
 
-	public void setWidth(float width) throws DOMException;
+	/**
+	 * The width.
+	 * 
+	 * @return the width in user units.
+	 */
+	float getWidth();
 
-	public float getHeight();
+	/**
+	 * Sets the width of the rectangle.
+	 * 
+	 * @param width the width in user units.
+	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR if the rectangle corresponds
+	 *                      to a read only attribute or when the object itself is
+	 *                      read only.
+	 */
+	void setWidth(float width) throws DOMException;
 
-	public void setHeight(float height) throws DOMException;
+	/**
+	 * The height.
+	 * 
+	 * @return the height in user units.
+	 */
+	float getHeight();
+
+	/**
+	 * Sets the height of the rectangle.
+	 * 
+	 * @param height the height in user units.
+	 * @throws DOMException NO_MODIFICATION_ALLOWED_ERR if the rectangle corresponds
+	 *                      to a read only attribute or when the object itself is
+	 *                      read only.
+	 */
+	void setHeight(float height) throws DOMException;
+
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGRectElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGRectElement.java
@@ -16,15 +16,15 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGRectElement extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable,
 		SVGTransformable, EventTarget {
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 
-	public SVGAnimatedLength getRx();
+	SVGAnimatedLength getRx();
 
-	public SVGAnimatedLength getRy();
+	SVGAnimatedLength getRy();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGRenderingIntent.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGRenderingIntent.java
@@ -14,10 +14,10 @@ package org.w3c.dom.svg;
 
 public interface SVGRenderingIntent {
 	// Rendering Intent Types
-	public static final short RENDERING_INTENT_UNKNOWN = 0;
-	public static final short RENDERING_INTENT_AUTO = 1;
-	public static final short RENDERING_INTENT_PERCEPTUAL = 2;
-	public static final short RENDERING_INTENT_RELATIVE_COLORIMETRIC = 3;
-	public static final short RENDERING_INTENT_SATURATION = 4;
-	public static final short RENDERING_INTENT_ABSOLUTE_COLORIMETRIC = 5;
+	short RENDERING_INTENT_UNKNOWN = 0;
+	short RENDERING_INTENT_AUTO = 1;
+	short RENDERING_INTENT_PERCEPTUAL = 2;
+	short RENDERING_INTENT_RELATIVE_COLORIMETRIC = 3;
+	short RENDERING_INTENT_SATURATION = 4;
+	short RENDERING_INTENT_ABSOLUTE_COLORIMETRIC = 5;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGSVGElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGSVGElement.java
@@ -22,87 +22,87 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGSVGElement extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable,
 		SVGLocatable, SVGFitToViewBox, SVGZoomAndPan, EventTarget, DocumentEvent, ViewCSS, DocumentCSS {
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 
-	public String getContentScriptType();
+	String getContentScriptType();
 
-	public void setContentScriptType(String contentScriptType) throws DOMException;
+	void setContentScriptType(String contentScriptType) throws DOMException;
 
-	public String getContentStyleType();
+	String getContentStyleType();
 
-	public void setContentStyleType(String contentStyleType) throws DOMException;
+	void setContentStyleType(String contentStyleType) throws DOMException;
 
-	public SVGRect getViewport();
+	SVGRect getViewport();
 
-	public float getPixelUnitToMillimeterX();
+	float getPixelUnitToMillimeterX();
 
-	public float getPixelUnitToMillimeterY();
+	float getPixelUnitToMillimeterY();
 
-	public float getScreenPixelToMillimeterX();
+	float getScreenPixelToMillimeterX();
 
-	public float getScreenPixelToMillimeterY();
+	float getScreenPixelToMillimeterY();
 
-	public boolean getUseCurrentView();
+	boolean getUseCurrentView();
 
-	public void setUseCurrentView(boolean useCurrentView) throws DOMException;
+	void setUseCurrentView(boolean useCurrentView) throws DOMException;
 
-	public SVGViewSpec getCurrentView();
+	SVGViewSpec getCurrentView();
 
-	public float getCurrentScale();
+	float getCurrentScale();
 
-	public void setCurrentScale(float currentScale) throws DOMException;
+	void setCurrentScale(float currentScale) throws DOMException;
 
-	public SVGPoint getCurrentTranslate();
+	SVGPoint getCurrentTranslate();
 
-	public int suspendRedraw(int max_wait_milliseconds);
+	int suspendRedraw(int max_wait_milliseconds);
 
-	public void unsuspendRedraw(int suspend_handle_id) throws DOMException;
+	void unsuspendRedraw(int suspend_handle_id) throws DOMException;
 
-	public void unsuspendRedrawAll();
+	void unsuspendRedrawAll();
 
-	public void forceRedraw();
+	void forceRedraw();
 
-	public void pauseAnimations();
+	void pauseAnimations();
 
-	public void unpauseAnimations();
+	void unpauseAnimations();
 
-	public boolean animationsPaused();
+	boolean animationsPaused();
 
-	public float getCurrentTime();
+	float getCurrentTime();
 
-	public void setCurrentTime(float seconds);
+	void setCurrentTime(float seconds);
 
-	public NodeList getIntersectionList(SVGRect rect, SVGElement referenceElement);
+	NodeList getIntersectionList(SVGRect rect, SVGElement referenceElement);
 
-	public NodeList getEnclosureList(SVGRect rect, SVGElement referenceElement);
+	NodeList getEnclosureList(SVGRect rect, SVGElement referenceElement);
 
-	public boolean checkIntersection(SVGElement element, SVGRect rect);
+	boolean checkIntersection(SVGElement element, SVGRect rect);
 
-	public boolean checkEnclosure(SVGElement element, SVGRect rect);
+	boolean checkEnclosure(SVGElement element, SVGRect rect);
 
-	public void deselectAll();
+	void deselectAll();
 
-	public SVGNumber createSVGNumber();
+	SVGNumber createSVGNumber();
 
-	public SVGLength createSVGLength();
+	SVGLength createSVGLength();
 
-	public SVGAngle createSVGAngle();
+	SVGAngle createSVGAngle();
 
-	public SVGPoint createSVGPoint();
+	SVGPoint createSVGPoint();
 
-	public SVGMatrix createSVGMatrix();
+	SVGMatrix createSVGMatrix();
 
-	public SVGRect createSVGRect();
+	SVGRect createSVGRect();
 
-	public SVGTransform createSVGTransform();
+	SVGTransform createSVGTransform();
 
-	public SVGTransform createSVGTransformFromMatrix(SVGMatrix matrix);
+	SVGTransform createSVGTransformFromMatrix(SVGMatrix matrix);
 
-	public Element getElementById(String elementId);
+	Element getElementById(String elementId);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGScriptElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGScriptElement.java
@@ -15,7 +15,7 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGScriptElement extends SVGElement, SVGURIReference, SVGExternalResourcesRequired {
-	public String getType();
+	String getType();
 
-	public void setType(String type) throws DOMException;
+	void setType(String type) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGStopElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGStopElement.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGStopElement extends SVGElement, SVGStylable {
-	public SVGAnimatedNumber getOffset();
+	SVGAnimatedNumber getOffset();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGStringList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGStringList.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGStringList {
-	public int getNumberOfItems();
+	int getNumberOfItems();
 
-	public void clear() throws DOMException;
+	void clear() throws DOMException;
 
-	public String initialize(String newItem) throws DOMException, SVGException;
+	String initialize(String newItem) throws DOMException, SVGException;
 
-	public String getItem(int index) throws DOMException;
+	String getItem(int index) throws DOMException;
 
-	public String insertItemBefore(String newItem, int index) throws DOMException, SVGException;
+	String insertItemBefore(String newItem, int index) throws DOMException, SVGException;
 
-	public String replaceItem(String newItem, int index) throws DOMException, SVGException;
+	String replaceItem(String newItem, int index) throws DOMException, SVGException;
 
-	public String removeItem(int index) throws DOMException;
+	String removeItem(int index) throws DOMException;
 
-	public String appendItem(String newItem) throws DOMException, SVGException;
+	String appendItem(String newItem) throws DOMException, SVGException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGStylable.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGStylable.java
@@ -27,6 +27,7 @@ public interface SVGStylable extends SVGStylableP<CSSValue> {
 	 * @param name the presentation attribute.
 	 * @return the given presentation attribute as an object.
 	 */
+	@Override
 	@Deprecated
 	default CSSValue getPresentationAttribute(String name) {
 		return null;

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGStylableP.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGStylableP.java
@@ -12,24 +12,37 @@
 
 package org.w3c.dom.svg;
 
-import org.w3c.dom.css.CSSValue;
+import org.w3c.css.om.CSSStyleDeclaration;
 
 /**
  * This interface is implemented on all objects corresponding to SVG elements
  * that can have <code>style</code>, <code>class</code> and presentation
  * attributes specified on them.
  */
-public interface SVGStylable extends SVGStylableP<CSSValue> {
+public interface SVGStylableP<V> {
 
 	/**
-	 * Returns the base value of a given presentation attribute as an object.
+	 * Gets the attribute {@code class} on this element.
+	 * 
+	 * @return the attribute {@code class}.
+	 */
+	SVGAnimatedString getClassName();
+
+	/**
+	 * Gets the inline style of this element.
+	 * 
+	 * @return the inline style.
+	 */
+	CSSStyleDeclaration getStyle();
+
+	/**
+	 * Returns the base value of a given presentation attribute as an object of type
+	 * {@code V}.
 	 * 
 	 * @param name the presentation attribute.
 	 * @return the given presentation attribute as an object.
 	 */
 	@Deprecated
-	default CSSValue getPresentationAttribute(String name) {
-		return null;
-	}
+	V getPresentationAttribute(String name);
 
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGStyleElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGStyleElement.java
@@ -15,19 +15,19 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGStyleElement extends SVGElement {
-	public String getXMLspace();
+	String getXMLspace();
 
-	public void setXMLspace(String xmlspace) throws DOMException;
+	void setXMLspace(String xmlspace) throws DOMException;
 
-	public String getType();
+	String getType();
 
-	public void setType(String type) throws DOMException;
+	void setType(String type) throws DOMException;
 
-	public String getMedia();
+	String getMedia();
 
-	public void setMedia(String media) throws DOMException;
+	void setMedia(String media) throws DOMException;
 
-	public String getTitle();
+	String getTitle();
 
-	public void setTitle(String title) throws DOMException;
+	void setTitle(String title) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGTests.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGTests.java
@@ -13,11 +13,11 @@
 package org.w3c.dom.svg;
 
 public interface SVGTests {
-	public SVGStringList getRequiredFeatures();
+	SVGStringList getRequiredFeatures();
 
-	public SVGStringList getRequiredExtensions();
+	SVGStringList getRequiredExtensions();
 
-	public SVGStringList getSystemLanguage();
+	SVGStringList getSystemLanguage();
 
-	public boolean hasExtension(String extension);
+	boolean hasExtension(String extension);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGTextContentElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGTextContentElement.java
@@ -18,29 +18,29 @@ import org.w3c.dom.events.EventTarget;
 public interface SVGTextContentElement
 		extends SVGElement, SVGTests, SVGLangSpace, SVGExternalResourcesRequired, SVGStylable, EventTarget {
 	// lengthAdjust Types
-	public static final short LENGTHADJUST_UNKNOWN = 0;
-	public static final short LENGTHADJUST_SPACING = 1;
-	public static final short LENGTHADJUST_SPACINGANDGLYPHS = 2;
+	short LENGTHADJUST_UNKNOWN = 0;
+	short LENGTHADJUST_SPACING = 1;
+	short LENGTHADJUST_SPACINGANDGLYPHS = 2;
 
-	public SVGAnimatedLength getTextLength();
+	SVGAnimatedLength getTextLength();
 
-	public SVGAnimatedEnumeration getLengthAdjust();
+	SVGAnimatedEnumeration getLengthAdjust();
 
-	public int getNumberOfChars();
+	int getNumberOfChars();
 
-	public float getComputedTextLength();
+	float getComputedTextLength();
 
-	public float getSubStringLength(int charnum, int nchars) throws DOMException;
+	float getSubStringLength(int charnum, int nchars) throws DOMException;
 
-	public SVGPoint getStartPositionOfChar(int charnum) throws DOMException;
+	SVGPoint getStartPositionOfChar(int charnum) throws DOMException;
 
-	public SVGPoint getEndPositionOfChar(int charnum) throws DOMException;
+	SVGPoint getEndPositionOfChar(int charnum) throws DOMException;
 
-	public SVGRect getExtentOfChar(int charnum) throws DOMException;
+	SVGRect getExtentOfChar(int charnum) throws DOMException;
 
-	public float getRotationOfChar(int charnum) throws DOMException;
+	float getRotationOfChar(int charnum) throws DOMException;
 
-	public int getCharNumAtPosition(SVGPoint point);
+	int getCharNumAtPosition(SVGPoint point);
 
-	public void selectSubString(int charnum, int nchars) throws DOMException;
+	void selectSubString(int charnum, int nchars) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGTextPathElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGTextPathElement.java
@@ -14,17 +14,17 @@ package org.w3c.dom.svg;
 
 public interface SVGTextPathElement extends SVGTextContentElement, SVGURIReference {
 	// textPath Method Types
-	public static final short TEXTPATH_METHODTYPE_UNKNOWN = 0;
-	public static final short TEXTPATH_METHODTYPE_ALIGN = 1;
-	public static final short TEXTPATH_METHODTYPE_STRETCH = 2;
+	short TEXTPATH_METHODTYPE_UNKNOWN = 0;
+	short TEXTPATH_METHODTYPE_ALIGN = 1;
+	short TEXTPATH_METHODTYPE_STRETCH = 2;
 	// textPath Spacing Types
-	public static final short TEXTPATH_SPACINGTYPE_UNKNOWN = 0;
-	public static final short TEXTPATH_SPACINGTYPE_AUTO = 1;
-	public static final short TEXTPATH_SPACINGTYPE_EXACT = 2;
+	short TEXTPATH_SPACINGTYPE_UNKNOWN = 0;
+	short TEXTPATH_SPACINGTYPE_AUTO = 1;
+	short TEXTPATH_SPACINGTYPE_EXACT = 2;
 
-	public SVGAnimatedLength getStartOffset();
+	SVGAnimatedLength getStartOffset();
 
-	public SVGAnimatedEnumeration getMethod();
+	SVGAnimatedEnumeration getMethod();
 
-	public SVGAnimatedEnumeration getSpacing();
+	SVGAnimatedEnumeration getSpacing();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGTextPositioningElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGTextPositioningElement.java
@@ -13,13 +13,13 @@
 package org.w3c.dom.svg;
 
 public interface SVGTextPositioningElement extends SVGTextContentElement {
-	public SVGAnimatedLengthList getX();
+	SVGAnimatedLengthList getX();
 
-	public SVGAnimatedLengthList getY();
+	SVGAnimatedLengthList getY();
 
-	public SVGAnimatedLengthList getDx();
+	SVGAnimatedLengthList getDx();
 
-	public SVGAnimatedLengthList getDy();
+	SVGAnimatedLengthList getDy();
 
-	public SVGAnimatedNumberList getRotate();
+	SVGAnimatedNumberList getRotate();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGTransform.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGTransform.java
@@ -14,29 +14,29 @@ package org.w3c.dom.svg;
 
 public interface SVGTransform {
 	// Transform Types
-	public static final short SVG_TRANSFORM_UNKNOWN = 0;
-	public static final short SVG_TRANSFORM_MATRIX = 1;
-	public static final short SVG_TRANSFORM_TRANSLATE = 2;
-	public static final short SVG_TRANSFORM_SCALE = 3;
-	public static final short SVG_TRANSFORM_ROTATE = 4;
-	public static final short SVG_TRANSFORM_SKEWX = 5;
-	public static final short SVG_TRANSFORM_SKEWY = 6;
+	short SVG_TRANSFORM_UNKNOWN = 0;
+	short SVG_TRANSFORM_MATRIX = 1;
+	short SVG_TRANSFORM_TRANSLATE = 2;
+	short SVG_TRANSFORM_SCALE = 3;
+	short SVG_TRANSFORM_ROTATE = 4;
+	short SVG_TRANSFORM_SKEWX = 5;
+	short SVG_TRANSFORM_SKEWY = 6;
 
-	public short getType();
+	short getType();
 
-	public SVGMatrix getMatrix();
+	SVGMatrix getMatrix();
 
-	public float getAngle();
+	float getAngle();
 
-	public void setMatrix(SVGMatrix matrix);
+	void setMatrix(SVGMatrix matrix);
 
-	public void setTranslate(float tx, float ty);
+	void setTranslate(float tx, float ty);
 
-	public void setScale(float sx, float sy);
+	void setScale(float sx, float sy);
 
-	public void setRotate(float angle, float cx, float cy);
+	void setRotate(float angle, float cx, float cy);
 
-	public void setSkewX(float angle);
+	void setSkewX(float angle);
 
-	public void setSkewY(float angle);
+	void setSkewY(float angle);
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGTransformList.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGTransformList.java
@@ -15,23 +15,23 @@ package org.w3c.dom.svg;
 import org.w3c.dom.DOMException;
 
 public interface SVGTransformList {
-	public int getNumberOfItems();
+	int getNumberOfItems();
 
-	public void clear() throws DOMException;
+	void clear() throws DOMException;
 
-	public SVGTransform initialize(SVGTransform newItem) throws DOMException, SVGException;
+	SVGTransform initialize(SVGTransform newItem) throws DOMException, SVGException;
 
-	public SVGTransform getItem(int index) throws DOMException;
+	SVGTransform getItem(int index) throws DOMException;
 
-	public SVGTransform insertItemBefore(SVGTransform newItem, int index) throws DOMException, SVGException;
+	SVGTransform insertItemBefore(SVGTransform newItem, int index) throws DOMException, SVGException;
 
-	public SVGTransform replaceItem(SVGTransform newItem, int index) throws DOMException, SVGException;
+	SVGTransform replaceItem(SVGTransform newItem, int index) throws DOMException, SVGException;
 
-	public SVGTransform removeItem(int index) throws DOMException;
+	SVGTransform removeItem(int index) throws DOMException;
 
-	public SVGTransform appendItem(SVGTransform newItem) throws DOMException, SVGException;
+	SVGTransform appendItem(SVGTransform newItem) throws DOMException, SVGException;
 
-	public SVGTransform createSVGTransformFromMatrix(SVGMatrix matrix);
+	SVGTransform createSVGTransformFromMatrix(SVGMatrix matrix);
 
-	public SVGTransform consolidate();
+	SVGTransform consolidate();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGTransformable.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGTransformable.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGTransformable extends SVGLocatable {
-	public SVGAnimatedTransformList getTransform();
+	SVGAnimatedTransformList getTransform();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGURIReference.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGURIReference.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGURIReference {
-	public SVGAnimatedString getHref();
+	SVGAnimatedString getHref();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGUnitTypes.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGUnitTypes.java
@@ -14,7 +14,7 @@ package org.w3c.dom.svg;
 
 public interface SVGUnitTypes {
 	// Unit Types
-	public static final short SVG_UNIT_TYPE_UNKNOWN = 0;
-	public static final short SVG_UNIT_TYPE_USERSPACEONUSE = 1;
-	public static final short SVG_UNIT_TYPE_OBJECTBOUNDINGBOX = 2;
+	short SVG_UNIT_TYPE_UNKNOWN = 0;
+	short SVG_UNIT_TYPE_USERSPACEONUSE = 1;
+	short SVG_UNIT_TYPE_OBJECTBOUNDINGBOX = 2;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGUseElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGUseElement.java
@@ -16,15 +16,15 @@ import org.w3c.dom.events.EventTarget;
 
 public interface SVGUseElement extends SVGElement, SVGURIReference, SVGTests, SVGLangSpace,
 		SVGExternalResourcesRequired, SVGStylable, SVGTransformable, EventTarget {
-	public SVGAnimatedLength getX();
+	SVGAnimatedLength getX();
 
-	public SVGAnimatedLength getY();
+	SVGAnimatedLength getY();
 
-	public SVGAnimatedLength getWidth();
+	SVGAnimatedLength getWidth();
 
-	public SVGAnimatedLength getHeight();
+	SVGAnimatedLength getHeight();
 
-	public SVGElementInstance getInstanceRoot();
+	SVGElementInstance getInstanceRoot();
 
-	public SVGElementInstance getAnimatedInstanceRoot();
+	SVGElementInstance getAnimatedInstanceRoot();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGViewElement.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGViewElement.java
@@ -13,5 +13,5 @@
 package org.w3c.dom.svg;
 
 public interface SVGViewElement extends SVGElement, SVGExternalResourcesRequired, SVGFitToViewBox, SVGZoomAndPan {
-	public SVGStringList getViewTarget();
+	SVGStringList getViewTarget();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGViewSpec.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGViewSpec.java
@@ -13,15 +13,15 @@
 package org.w3c.dom.svg;
 
 public interface SVGViewSpec extends SVGZoomAndPan, SVGFitToViewBox {
-	public SVGTransformList getTransform();
+	SVGTransformList getTransform();
 
-	public SVGElement getViewTarget();
+	SVGElement getViewTarget();
 
-	public String getViewBoxString();
+	String getViewBoxString();
 
-	public String getPreserveAspectRatioString();
+	String getPreserveAspectRatioString();
 
-	public String getTransformString();
+	String getTransformString();
 
-	public String getViewTargetString();
+	String getViewTargetString();
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGZoomAndPan.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGZoomAndPan.java
@@ -16,11 +16,11 @@ import org.w3c.dom.DOMException;
 
 public interface SVGZoomAndPan {
 	// Zoom and Pan Types
-	public static final short SVG_ZOOMANDPAN_UNKNOWN = 0;
-	public static final short SVG_ZOOMANDPAN_DISABLE = 1;
-	public static final short SVG_ZOOMANDPAN_MAGNIFY = 2;
+	short SVG_ZOOMANDPAN_UNKNOWN = 0;
+	short SVG_ZOOMANDPAN_DISABLE = 1;
+	short SVG_ZOOMANDPAN_MAGNIFY = 2;
 
-	public short getZoomAndPan();
+	short getZoomAndPan();
 
-	public void setZoomAndPan(short zoomAndPan) throws DOMException;
+	void setZoomAndPan(short zoomAndPan) throws DOMException;
 }

--- a/svgom-api/src/main/java/org/w3c/dom/svg/SVGZoomEvent.java
+++ b/svgom-api/src/main/java/org/w3c/dom/svg/SVGZoomEvent.java
@@ -15,13 +15,13 @@ package org.w3c.dom.svg;
 import org.w3c.dom.events.UIEvent;
 
 public interface SVGZoomEvent extends UIEvent {
-	public SVGRect getZoomRectScreen();
+	SVGRect getZoomRectScreen();
 
-	public float getPreviousScale();
+	float getPreviousScale();
 
-	public SVGPoint getPreviousTranslate();
+	SVGPoint getPreviousTranslate();
 
-	public float getNewScale();
+	float getNewScale();
 
-	public SVGPoint getNewTranslate();
+	SVGPoint getNewTranslate();
 }


### PR DESCRIPTION
Parameterizes `SVGStylable` and makes it return a `CSSStyleDeclaration` compatible with Typed OM.

Now `SVGStylable` should be compatible with both the new and the old API.